### PR TITLE
Fix add_cell/insert_cell missing execution_count for code cells

### DIFF
--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -395,6 +395,9 @@ async def add_cell(
                 "cell_type": cell_type,
                 "source": "",
             }
+            if cell_type == "code":
+                cell["execution_count"] = None
+                cell["outputs"] = []
             ycell = ydoc.create_ycell(cell)
             if insert_index >= cells_count:
                 ydoc.ycells.append(ycell)
@@ -468,6 +471,9 @@ async def insert_cell(
                 "cell_type": cell_type,
                 "source": "",
             }
+            if cell_type == "code":
+                cell["execution_count"] = None
+                cell["outputs"] = []
             ycell = ydoc.create_ycell(cell)
             if insert_index >= cells_count:
                 ydoc.ycells.append(ycell)


### PR DESCRIPTION
## Summary

- `add_cell()` and `insert_cell()` create code cells via `ydoc.create_ycell()` with only `cell_type` and `source`
- nbformat v4 requires `execution_count` on code cells (can be `null`, but the key must exist)
- `create_ycell()` doesn't inject it — it handles `outputs` and `execution_state`, but not `execution_count`
- This causes `Notebook JSON is invalid: 'execution_count' is a required property` errors every ~500ms during the collaboration save loop

## Fix

Add `execution_count: None` and `outputs: []` to the cell dict before passing to `create_ycell()` for code cells. This matches what `nbformat.v4.new_code_cell()` does in the filesystem fallback path.

## Test plan

- [ ] Open a notebook with collaboration enabled
- [ ] Use AI agent to add a code cell
- [ ] Confirm no `execution_count` validation errors in server logs
- [ ] Confirm cell is created and editable

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)