### PR TITLE
Use atomic write_to_cell_collaboratively by default, opt-in typing animation via animate flag

### DIFF
--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -647,26 +647,24 @@ def set_cursor_in_ynotebook(
 
 
 async def write_to_cell_collaboratively(
-    ynotebook, ycell, content: str, typing_speed: float = 0.1
+    ynotebook, ycell, content: str, typing_speed: float = 0.1, animate: bool = False
 ) -> bool:
     """
-    Writes content to a Jupyter notebook cell with collaborative typing simulation.
+    Writes content to a Jupyter notebook cell.
 
-    This function provides a collaborative writing experience by applying text changes
-    incrementally with visual feedback. It uses a diff-based approach to compute the
-    minimal set of changes needed and applies them with cursor positioning and timing
-    delays to simulate natural typing behavior.
+    With animate=False (default), performs an atomic replace: deletes the old content and
+    inserts the new content with no await between CRDT operations. Safe under concurrent edits.
 
-    The function handles three types of operations:
-    - Delete: Removes text with visual highlighting
-    - Insert: Adds text word-by-word with typing delays
-    - Replace: Combines delete and insert operations
+    With animate=True, applies a diff-based typing simulation with cursor movement and timing
+    delays. Produces a visible typing effect, but is not safe under concurrent edits — stale
+    position references may cause a panic in pycrdt's Rust layer.
 
     Args:
         ynotebook: The YNotebook instance representing the collaborative notebook
         ycell: The YCell instance representing the specific cell to modify
         content: The new content to write to the cell
         typing_speed: Delay in seconds between typing operations (default: 0.1)
+        animate: If True, use diff-based typing animation (default: False)
 
     Returns:
         bool: True if the operation completed successfully
@@ -675,15 +673,6 @@ async def write_to_cell_collaboratively(
         ValueError: If ynotebook/ycell is None or typing_speed is negative
         TypeError: If content is not a string
         RuntimeError: If cell content extraction or writing fails
-
-    Example:
-        >>> # Write with default typing speed
-        >>> success = await write_to_cell_collaboratively(ynotebook, ycell, "print('Hello')")
-        >>>
-        >>> # Write with custom typing speed (faster)
-        >>> success = await write_to_cell_collaboratively(
-        ...     ynotebook, ycell, "print('World')", typing_speed=0.05
-        ... )
     """
     # Input validation
     if ynotebook is None:
@@ -701,69 +690,74 @@ async def write_to_cell_collaboratively(
         old_content = cell.get("source", "")
         cell_source = ycell["source"]  # YText object for collaborative editing
         new_content = content
-
-        # Early return if content is unchanged
-        if old_content == new_content:
-            return True
-
     except Exception as e:
         raise RuntimeError(f"Failed to extract cell content: {e}")
 
-    try:
-        # Compute the minimal set of changes needed using difflib
-        sequence_matcher = difflib.SequenceMatcher(None, old_content, new_content)
-        cursor_position = 0
-
-        # Set initial cursor position
-        _safe_set_cursor(ynotebook, cell_source, cursor_position)
-
-        # Apply each change operation sequentially
-        for operation, old_start, old_end, new_start, new_end in sequence_matcher.get_opcodes():
-            if operation == "equal":
-                # No changes needed for this segment, just advance cursor
-                cursor_position += old_end - old_start
-
-            elif operation == "delete":
-                # Remove text with visual feedback
-                delete_length = old_end - old_start
-                await _handle_delete_operation(
-                    ynotebook, cell_source, cursor_position, delete_length, typing_speed
-                )
-                # Cursor stays at same position after deletion
-
-            elif operation == "insert":
-                # Add text with typing simulation
-                cursor_position = await _handle_insert_operation(
-                    ynotebook,
-                    cell_source,
-                    cursor_position,
-                    new_content,
-                    new_start,
-                    new_end,
-                    typing_speed,
-                )
-
-            elif operation == "replace":
-                # Combine delete and insert operations
-                delete_length = old_end - old_start
-                cursor_position = await _handle_replace_operation(
-                    ynotebook,
-                    cell_source,
-                    cursor_position,
-                    new_content,
-                    delete_length,
-                    new_start,
-                    new_end,
-                    typing_speed,
-                )
-
-        # Set final cursor position at the end of the content
-        _safe_set_cursor(ynotebook, cell_source, cursor_position)
-
+    # Early return if content is unchanged
+    if old_content == new_content:
         return True
 
-    except Exception as e:
-        raise RuntimeError(f"Failed to write cell content collaboratively: {e}")
+    if animate:
+        try:
+            # Compute the minimal set of changes needed using difflib
+            sequence_matcher = difflib.SequenceMatcher(None, old_content, new_content)
+            cursor_position = 0
+
+            # Set initial cursor position
+            _safe_set_cursor(ynotebook, cell_source, cursor_position)
+
+            # Apply each change operation sequentially
+            for operation, old_start, old_end, new_start, new_end in sequence_matcher.get_opcodes():
+                if operation == "equal":
+                    # No changes needed for this segment, just advance cursor
+                    cursor_position += old_end - old_start
+
+                elif operation == "delete":
+                    # Remove text with visual feedback
+                    delete_length = old_end - old_start
+                    await _handle_delete_operation(
+                        ynotebook, cell_source, cursor_position, delete_length, typing_speed
+                    )
+                    # Cursor stays at same position after deletion
+
+                elif operation == "insert":
+                    # Add text with typing simulation
+                    cursor_position = await _handle_insert_operation(
+                        ynotebook,
+                        cell_source,
+                        cursor_position,
+                        new_content,
+                        new_start,
+                        new_end,
+                        typing_speed,
+                    )
+
+                elif operation == "replace":
+                    # Combine delete and insert operations
+                    delete_length = old_end - old_start
+                    cursor_position = await _handle_replace_operation(
+                        ynotebook,
+                        cell_source,
+                        cursor_position,
+                        new_content,
+                        delete_length,
+                        new_start,
+                        new_end,
+                        typing_speed,
+                    )
+
+            # Set final cursor position at the end of the content
+            _safe_set_cursor(ynotebook, cell_source, cursor_position)
+
+            return True
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to write cell content collaboratively in animation mode): {e}")
+
+    # Default: atomic replace — no await between CRDT ops, no stale positions.
+    del cell_source[0:len(old_content)]
+    cell_source.insert(0, content)
+    return True
 
 
 async def _handle_delete_operation(

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -668,11 +668,17 @@ async def write_to_cell_collaboratively(
     ynotebook, ycell, content: str, typing_speed: float = 0.1
 ) -> bool:
     """
-    Writes content to a Jupyter notebook cell with diff-based typing simulation.
+    Writes content to a Jupyter notebook cell with collaborative typing simulation.
 
-    Applies a typing animation with cursor movement and timing delays. Not safe under
-    concurrent edits — stale position references may cause a panic in pycrdt's Rust layer.
-    Use the atomic inline replace (del + insert on the YText) for the default safe path.
+    This function provides a collaborative writing experience by applying text changes
+    incrementally with visual feedback. It uses a diff-based approach to compute the
+    minimal set of changes needed and applies them with cursor positioning and timing
+    delays to simulate natural typing behavior.
+
+    The function handles three types of operations:
+    - Delete: Removes text with visual highlighting
+    - Insert: Adds text word-by-word with typing delays
+    - Replace: Combines delete and insert operations
 
     Args:
         ynotebook: The YNotebook instance representing the collaborative notebook
@@ -687,6 +693,15 @@ async def write_to_cell_collaboratively(
         ValueError: If ynotebook/ycell is None or typing_speed is negative
         TypeError: If content is not a string
         RuntimeError: If cell content extraction or writing fails
+
+    Example:
+        >>> # Write with default typing speed
+        >>> success = await write_to_cell_collaboratively(ynotebook, ycell, "print('Hello')")
+        >>>
+        >>> # Write with custom typing speed (faster)
+        >>> success = await write_to_cell_collaboratively(
+        ...     ynotebook, ycell, "print('World')", typing_speed=0.05
+        ... )
     """
     # Input validation
     if ynotebook is None:
@@ -704,12 +719,13 @@ async def write_to_cell_collaboratively(
         old_content = cell.get("source", "")
         cell_source = ycell["source"]  # YText object for collaborative editing
         new_content = content
+
+        # Early return if content is unchanged
+        if old_content == new_content:
+            return True
+
     except Exception as e:
         raise RuntimeError(f"Failed to extract cell content: {e}")
-
-    # Early return if content is unchanged
-    if old_content == new_content:
-        return True
 
     try:
         # Compute the minimal set of changes needed using difflib
@@ -765,7 +781,7 @@ async def write_to_cell_collaboratively(
         return True
 
     except Exception as e:
-        raise RuntimeError(f"Failed to write cell content collaboratively in animation mode): {e}")
+        raise RuntimeError(f"Failed to write cell content collaboratively: {e}")
 
 
 async def _handle_delete_operation(

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -351,6 +351,7 @@ async def add_cell(
     cell_id: Optional[str] = None,
     add_above: bool = False,
     cell_type: Literal["code", "markdown", "raw"] = "code",
+    animate: bool = False,
 ):
     """Adds a new cell to the Jupyter notebook above or below a specified cell.
 
@@ -403,7 +404,7 @@ async def add_cell(
                 ydoc.ycells.append(ycell)
             else:
                 ydoc.ycells.insert(insert_index, ycell)
-            await write_to_cell_collaboratively(ydoc, ycell, content or "")
+            await write_to_cell_collaboratively(ydoc, ycell, content or "", animate=animate)
         else:
             with open(file_path, "r", encoding="utf-8") as f:
                 notebook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
@@ -438,6 +439,7 @@ async def insert_cell(
     content: Optional[str] = None,
     insert_index: Optional[int] = None,
     cell_type: Literal["code", "markdown", "raw"] = "code",
+    animate: bool = False,
 ):
     """Inserts a new cell to the Jupyter notebook at the specified cell index.
 
@@ -479,7 +481,7 @@ async def insert_cell(
                 ydoc.ycells.append(ycell)
             else:
                 ydoc.ycells.insert(insert_index, ycell)
-            await write_to_cell_collaboratively(ydoc, ycell, content or "")
+            await write_to_cell_collaboratively(ydoc, ycell, content or "", animate=animate)
         else:
             with open(file_path, "r", encoding="utf-8") as f:
                 notebook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
@@ -1087,7 +1089,7 @@ async def select_cell(cell_id: str, username: Optional[str] = None) -> dict:
         raise
 
 
-async def edit_cell(file_path: str, cell_id: str, content: str) -> None:
+async def edit_cell(file_path: str, cell_id: str, content: str, animate: bool = False) -> None:
     """Edits the content of a notebook cell with the specified ID
 
     This function modifies the content of a cell in a Jupyter notebook. It first attempts to use
@@ -1121,7 +1123,7 @@ async def edit_cell(file_path: str, cell_id: str, content: str) -> None:
             cell_index = _get_cell_index_from_id_ydoc(ydoc, resolved_cell_id)
             if cell_index is not None:
                 ycell = ydoc._ycells[cell_index]
-                await write_to_cell_collaboratively(ydoc, ycell, content)
+                await write_to_cell_collaboratively(ydoc, ycell, content, animate=animate)
             else:
                 raise ValueError(f"Cell with {cell_id=} not found in notebook")
         else:

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -404,7 +404,10 @@ async def add_cell(
                 ydoc.ycells.append(ycell)
             else:
                 ydoc.ycells.insert(insert_index, ycell)
-            await write_to_cell_collaboratively(ydoc, ycell, content or "", animate=animate)
+            if animate:
+                await write_to_cell_collaboratively(ydoc, ycell, content or "")
+            else:
+                _atomic_replace_cell_source(ycell, content or "")
         else:
             with open(file_path, "r", encoding="utf-8") as f:
                 notebook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
@@ -481,7 +484,10 @@ async def insert_cell(
                 ydoc.ycells.append(ycell)
             else:
                 ydoc.ycells.insert(insert_index, ycell)
-            await write_to_cell_collaboratively(ydoc, ycell, content or "", animate=animate)
+            if animate:
+                await write_to_cell_collaboratively(ydoc, ycell, content or "")
+            else:
+                _atomic_replace_cell_source(ycell, content or "")
         else:
             with open(file_path, "r", encoding="utf-8") as f:
                 notebook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
@@ -648,25 +654,31 @@ def set_cursor_in_ynotebook(
         pass
 
 
+def _atomic_replace_cell_source(ycell, content: str) -> None:
+    """Atomically replaces cell source: del old content then insert new, no await between ops."""
+    old_content = ycell.to_py().get("source", "")
+    if old_content == content:
+        return
+    cell_source = ycell["source"]
+    del cell_source[0:len(old_content)]
+    cell_source.insert(0, content)
+
+
 async def write_to_cell_collaboratively(
-    ynotebook, ycell, content: str, typing_speed: float = 0.1, animate: bool = False
+    ynotebook, ycell, content: str, typing_speed: float = 0.1
 ) -> bool:
     """
-    Writes content to a Jupyter notebook cell.
+    Writes content to a Jupyter notebook cell with diff-based typing simulation.
 
-    With animate=False (default), performs an atomic replace: deletes the old content and
-    inserts the new content with no await between CRDT operations. Safe under concurrent edits.
-
-    With animate=True, applies a diff-based typing simulation with cursor movement and timing
-    delays. Produces a visible typing effect, but is not safe under concurrent edits — stale
-    position references may cause a panic in pycrdt's Rust layer.
+    Applies a typing animation with cursor movement and timing delays. Not safe under
+    concurrent edits — stale position references may cause a panic in pycrdt's Rust layer.
+    Use the atomic inline replace (del + insert on the YText) for the default safe path.
 
     Args:
         ynotebook: The YNotebook instance representing the collaborative notebook
         ycell: The YCell instance representing the specific cell to modify
         content: The new content to write to the cell
         typing_speed: Delay in seconds between typing operations (default: 0.1)
-        animate: If True, use diff-based typing animation (default: False)
 
     Returns:
         bool: True if the operation completed successfully
@@ -699,67 +711,61 @@ async def write_to_cell_collaboratively(
     if old_content == new_content:
         return True
 
-    if animate:
-        try:
-            # Compute the minimal set of changes needed using difflib
-            sequence_matcher = difflib.SequenceMatcher(None, old_content, new_content)
-            cursor_position = 0
+    try:
+        # Compute the minimal set of changes needed using difflib
+        sequence_matcher = difflib.SequenceMatcher(None, old_content, new_content)
+        cursor_position = 0
 
-            # Set initial cursor position
-            _safe_set_cursor(ynotebook, cell_source, cursor_position)
+        # Set initial cursor position
+        _safe_set_cursor(ynotebook, cell_source, cursor_position)
 
-            # Apply each change operation sequentially
-            for operation, old_start, old_end, new_start, new_end in sequence_matcher.get_opcodes():
-                if operation == "equal":
-                    # No changes needed for this segment, just advance cursor
-                    cursor_position += old_end - old_start
+        # Apply each change operation sequentially
+        for operation, old_start, old_end, new_start, new_end in sequence_matcher.get_opcodes():
+            if operation == "equal":
+                # No changes needed for this segment, just advance cursor
+                cursor_position += old_end - old_start
 
-                elif operation == "delete":
-                    # Remove text with visual feedback
-                    delete_length = old_end - old_start
-                    await _handle_delete_operation(
-                        ynotebook, cell_source, cursor_position, delete_length, typing_speed
-                    )
-                    # Cursor stays at same position after deletion
+            elif operation == "delete":
+                # Remove text with visual feedback
+                delete_length = old_end - old_start
+                await _handle_delete_operation(
+                    ynotebook, cell_source, cursor_position, delete_length, typing_speed
+                )
+                # Cursor stays at same position after deletion
 
-                elif operation == "insert":
-                    # Add text with typing simulation
-                    cursor_position = await _handle_insert_operation(
-                        ynotebook,
-                        cell_source,
-                        cursor_position,
-                        new_content,
-                        new_start,
-                        new_end,
-                        typing_speed,
-                    )
+            elif operation == "insert":
+                # Add text with typing simulation
+                cursor_position = await _handle_insert_operation(
+                    ynotebook,
+                    cell_source,
+                    cursor_position,
+                    new_content,
+                    new_start,
+                    new_end,
+                    typing_speed,
+                )
 
-                elif operation == "replace":
-                    # Combine delete and insert operations
-                    delete_length = old_end - old_start
-                    cursor_position = await _handle_replace_operation(
-                        ynotebook,
-                        cell_source,
-                        cursor_position,
-                        new_content,
-                        delete_length,
-                        new_start,
-                        new_end,
-                        typing_speed,
-                    )
+            elif operation == "replace":
+                # Combine delete and insert operations
+                delete_length = old_end - old_start
+                cursor_position = await _handle_replace_operation(
+                    ynotebook,
+                    cell_source,
+                    cursor_position,
+                    new_content,
+                    delete_length,
+                    new_start,
+                    new_end,
+                    typing_speed,
+                )
 
-            # Set final cursor position at the end of the content
-            _safe_set_cursor(ynotebook, cell_source, cursor_position)
+        # Set final cursor position at the end of the content
+        _safe_set_cursor(ynotebook, cell_source, cursor_position)
 
-            return True
+        return True
 
-        except Exception as e:
-            raise RuntimeError(f"Failed to write cell content collaboratively in animation mode): {e}")
-
-    # Default: atomic replace — no await between CRDT ops, no stale positions.
-    del cell_source[0:len(old_content)]
-    cell_source.insert(0, content)
-    return True
+    except Exception as e:
+        raise RuntimeError(f"Failed to write cell content collaboratively in animation mode): {e}")
 
 
 async def _handle_delete_operation(
@@ -1123,7 +1129,10 @@ async def edit_cell(file_path: str, cell_id: str, content: str, animate: bool = 
             cell_index = _get_cell_index_from_id_ydoc(ydoc, resolved_cell_id)
             if cell_index is not None:
                 ycell = ydoc._ycells[cell_index]
-                await write_to_cell_collaboratively(ydoc, ycell, content, animate=animate)
+                if animate:
+                    await write_to_cell_collaboratively(ydoc, ycell, content)
+                else:
+                    _atomic_replace_cell_source(ycell, content)
             else:
                 raise ValueError(f"Cell with {cell_id=} not found in notebook")
         else:

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -661,7 +661,7 @@ def _atomic_replace_cell_source(ycell, content: str) -> None:
         return
     cell_source = ycell["source"]
     cell_source.clear()
-    cell_source.insert(0, content)
+    cell_source += content
 
 
 async def write_to_cell_collaboratively(

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -655,12 +655,12 @@ def set_cursor_in_ynotebook(
 
 
 def _atomic_replace_cell_source(ycell, content: str) -> None:
-    """Atomically replaces cell source: del old content then insert new, no await between ops."""
+    """Atomically replaces cell source: clear then insert new, no await between ops."""
     old_content = ycell.to_py().get("source", "")
     if old_content == content:
         return
     cell_source = ycell["source"]
-    del cell_source[0:len(old_content)]
+    cell_source.clear()
     cell_source.insert(0, content)
 
 

--- a/tests/test_write_to_cell_collaboratively.py
+++ b/tests/test_write_to_cell_collaboratively.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from jupyter_ai_tools.toolkits.notebook import (
+    _atomic_replace_cell_source,
     _handle_delete_operation,
     _handle_insert_operation,
     _handle_replace_operation,
@@ -90,8 +91,7 @@ class TestWriteToCellCollaboratively:
         mock_handle_replace.return_value = 11  # new cursor position after replace
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
-        )
+            self.mock_ynotebook, self.mock_ycell, "new content"        )
 
         assert result is True
         mock_handle_replace.assert_called_once()
@@ -107,8 +107,7 @@ class TestWriteToCellCollaboratively:
 
         with pytest.raises(RuntimeError):
             await write_to_cell_collaboratively(
-                self.mock_ynotebook, self.mock_ycell, "new content", animate=True
-            )
+                self.mock_ynotebook, self.mock_ycell, "new content"            )
 
     @pytest.mark.asyncio
     @patch("jupyter_ai_tools.toolkits.notebook._safe_set_cursor")
@@ -124,8 +123,7 @@ class TestWriteToCellCollaboratively:
         mock_delete_op.return_value = None
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
-        )
+            self.mock_ynotebook, self.mock_ycell, "new content"        )
 
         assert result is True
         mock_delete_op.assert_called_once()
@@ -144,8 +142,7 @@ class TestWriteToCellCollaboratively:
         mock_insert_op.return_value = 5
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
-        )
+            self.mock_ynotebook, self.mock_ycell, "new content"        )
 
         assert result is True
         mock_insert_op.assert_called_once()
@@ -164,8 +161,7 @@ class TestWriteToCellCollaboratively:
         mock_replace_op.return_value = 7
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
-        )
+            self.mock_ynotebook, self.mock_ycell, "new content"        )
 
         assert result is True
         mock_replace_op.assert_called_once()
@@ -343,8 +339,7 @@ class TestIntegration:
         mock_source.__delitem__ = Mock()
 
         result = await write_to_cell_collaboratively(
-            mock_ynotebook, mock_ycell, "world", typing_speed=0.0, animate=True
-        )
+            mock_ynotebook, mock_ycell, "world", typing_speed=0.0        )
 
         assert result is True
         mock_source.insert.assert_called()
@@ -363,8 +358,7 @@ class TestIntegration:
         mock_source.insert = Mock()
 
         await write_to_cell_collaboratively(
-            mock_ynotebook, mock_ycell, "test", typing_speed=0.5, animate=True
-        )
+            mock_ynotebook, mock_ycell, "test", typing_speed=0.5        )
 
         mock_sleep.assert_called()
         sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
@@ -372,7 +366,7 @@ class TestIntegration:
 
 
 class TestAtomicReplace:
-    """Tests for the default atomic replace path (animate=False)."""
+    """Tests for the default atomic replace path (animate=True)."""
 
     def setup_method(self):
         self.mock_ynotebook = Mock()
@@ -383,27 +377,19 @@ class TestAtomicReplace:
         self.mock_source.insert = Mock()
         self.mock_source.__delitem__ = Mock()
 
-    @pytest.mark.asyncio
-    async def test_atomic_replace_calls_delete_then_insert(self):
+    def test_atomic_replace_calls_delete_then_insert(self):
         """del[0:len(old)] then insert(0, new) — correct args."""
-        result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content"
-        )
-        assert result is True
+        _atomic_replace_cell_source(self.mock_ycell, "new content")
         self.mock_source.__delitem__.assert_called_once_with(slice(0, len("old content")))
         self.mock_source.insert.assert_called_once_with(0, "new content")
 
-    @pytest.mark.asyncio
-    async def test_no_asyncio_sleep_called(self):
+    def test_no_asyncio_sleep_called(self):
         """No event loop yields between CRDT ops — the race condition fix."""
         with patch("jupyter_ai_tools.toolkits.notebook.asyncio.sleep") as mock_sleep:
-            await write_to_cell_collaboratively(
-                self.mock_ynotebook, self.mock_ycell, "new content"
-            )
+            _atomic_replace_cell_source(self.mock_ycell, "new content")
         mock_sleep.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_real_pycrdt_replace(self):
+    def test_real_pycrdt_replace(self):
         """Correct final content with real YText."""
         pycrdt = pytest.importorskip("pycrdt")
         doc = pycrdt.Doc()
@@ -414,36 +400,25 @@ class TestAtomicReplace:
         mock_ycell.to_py.return_value = {"source": "old content"}
         mock_ycell.__getitem__.return_value = source_text
 
-        result = await write_to_cell_collaboratively(Mock(), mock_ycell, "new content")
+        _atomic_replace_cell_source(mock_ycell, "new content")
 
-        assert result is True
         assert str(source_text) == "new content"
 
-    @pytest.mark.asyncio
-    async def test_atomic_replace_from_empty_cell(self):
+    def test_atomic_replace_from_empty_cell(self):
         """Write into a blank cell — del[0:0] is a no-op but insert must still run."""
         self.mock_ycell.to_py.return_value = {"source": ""}
-        result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "hello"
-        )
-        assert result is True
+        _atomic_replace_cell_source(self.mock_ycell, "hello")
         self.mock_source.__delitem__.assert_called_once_with(slice(0, 0))
         self.mock_source.insert.assert_called_once_with(0, "hello")
 
-    @pytest.mark.asyncio
-    async def test_atomic_replace_to_empty_cell(self):
+    def test_atomic_replace_to_empty_cell(self):
         """Clear a cell — delete runs, insert is called with empty string."""
-        result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, ""
-        )
-        assert result is True
+        _atomic_replace_cell_source(self.mock_ycell, "")
         self.mock_source.__delitem__.assert_called_once_with(slice(0, len("old content")))
         self.mock_source.insert.assert_called_once_with(0, "")
 
-    @pytest.mark.asyncio
-    async def test_concurrent_modification_does_not_panic(self):
-        """Concurrent CRDT modification must not cause a Rust panic (the original crash)."""
-        import asyncio as _asyncio
+    def test_no_panic_on_real_ytext(self):
+        """Atomic replace on real YText never panics regardless of content size."""
         pycrdt = pytest.importorskip("pycrdt")
         doc = pycrdt.Doc()
         source_text = doc.get("source", type=pycrdt.Text)
@@ -453,16 +428,8 @@ class TestAtomicReplace:
         mock_ycell.to_py.return_value = {"source": str(source_text)}
         mock_ycell.__getitem__.return_value = source_text
 
-        async def concurrent_clear():
-            await _asyncio.sleep(0)
-            current = str(source_text)
-            if current:
-                del source_text[0:len(current)]
-
-        await _asyncio.gather(
-            write_to_cell_collaboratively(Mock(), mock_ycell, "replacement"),
-            concurrent_clear(),
-        )
+        _atomic_replace_cell_source(mock_ycell, "replacement")
+        assert str(source_text) == "replacement"
 
 
 if __name__ == "__main__":

--- a/tests/test_write_to_cell_collaboratively.py
+++ b/tests/test_write_to_cell_collaboratively.py
@@ -377,10 +377,10 @@ class TestAtomicReplace:
         self.mock_source.insert = Mock()
         self.mock_source.__delitem__ = Mock()
 
-    def test_atomic_replace_calls_delete_then_insert(self):
-        """del[0:len(old)] then insert(0, new) — correct args."""
+    def test_atomic_replace_calls_clear_then_insert(self):
+        """clear() then insert(0, new) — correct ops."""
         _atomic_replace_cell_source(self.mock_ycell, "new content")
-        self.mock_source.__delitem__.assert_called_once_with(slice(0, len("old content")))
+        self.mock_source.clear.assert_called_once()
         self.mock_source.insert.assert_called_once_with(0, "new content")
 
     def test_no_asyncio_sleep_called(self):
@@ -405,16 +405,16 @@ class TestAtomicReplace:
         assert str(source_text) == "new content"
 
     def test_atomic_replace_from_empty_cell(self):
-        """Write into a blank cell — del[0:0] is a no-op but insert must still run."""
+        """Write into a blank cell — clear is a no-op but insert must still run."""
         self.mock_ycell.to_py.return_value = {"source": ""}
         _atomic_replace_cell_source(self.mock_ycell, "hello")
-        self.mock_source.__delitem__.assert_called_once_with(slice(0, 0))
+        self.mock_source.clear.assert_called_once()
         self.mock_source.insert.assert_called_once_with(0, "hello")
 
     def test_atomic_replace_to_empty_cell(self):
-        """Clear a cell — delete runs, insert is called with empty string."""
+        """Clear a cell — clear runs, insert is called with empty string."""
         _atomic_replace_cell_source(self.mock_ycell, "")
-        self.mock_source.__delitem__.assert_called_once_with(slice(0, len("old content")))
+        self.mock_source.clear.assert_called_once()
         self.mock_source.insert.assert_called_once_with(0, "")
 
     def test_no_panic_on_real_ytext(self):

--- a/tests/test_write_to_cell_collaboratively.py
+++ b/tests/test_write_to_cell_collaboratively.py
@@ -2,7 +2,7 @@
 Unit tests for the write_to_cell_collaboratively function and its helper functions.
 """
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -61,7 +61,7 @@ class TestWriteToCellCollaboratively:
 
     @pytest.mark.asyncio
     async def test_same_content_returns_true(self):
-        """Test that same content returns True immediately."""
+        """Test that same content returns True immediately without touching the CRDT."""
         self.mock_ycell.to_py.return_value = {"source": "same content"}
 
         result = await write_to_cell_collaboratively(
@@ -69,6 +69,8 @@ class TestWriteToCellCollaboratively:
         )
 
         assert result is True
+        self.mock_source.__delitem__.assert_not_called()
+        self.mock_source.insert.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_cell_extraction_error(self):
@@ -80,30 +82,33 @@ class TestWriteToCellCollaboratively:
 
     @pytest.mark.asyncio
     @patch("jupyter_ai_tools.toolkits.notebook._safe_set_cursor")
-    @patch("jupyter_ai_tools.toolkits.notebook.difflib.SequenceMatcher")
-    async def test_successful_write_operation(self, mock_sequence_matcher, mock_safe_set_cursor):
-        """Test successful write operation."""
-        # Mock SequenceMatcher to return simple equal operation
-        mock_sm = Mock()
-        mock_sm.get_opcodes.return_value = [("equal", 0, 5, 0, 5)]
-        mock_sequence_matcher.return_value = mock_sm
+    @patch("jupyter_ai_tools.toolkits.notebook._handle_replace_operation", new_callable=AsyncMock)
+    async def test_animated_replace_opcode_calls_handle_replace(
+        self, mock_handle_replace, mock_safe_set_cursor
+    ):
+        """Animated path dispatches a 'replace' opcode to _handle_replace_operation."""
+        mock_handle_replace.return_value = 11  # new cursor position after replace
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content"
+            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
         )
 
         assert result is True
-        mock_safe_set_cursor.assert_called()
+        mock_handle_replace.assert_called_once()
+        # Cursor should be set at least twice: initial + final
+        assert mock_safe_set_cursor.call_count >= 2
 
     @pytest.mark.asyncio
     @patch("jupyter_ai_tools.toolkits.notebook._safe_set_cursor")
     @patch("jupyter_ai_tools.toolkits.notebook.difflib.SequenceMatcher")
-    async def test_difflib_error_handling(self, mock_sequence_matcher, mock_safe_set_cursor):
-        """Test handling of difflib errors."""
+    async def test_difflib_error_propagates(self, mock_sequence_matcher, mock_safe_set_cursor):
+        """Errors in the animated path propagate — callers decide how to handle them."""
         mock_sequence_matcher.side_effect = Exception("Difflib error")
 
-        with pytest.raises(RuntimeError, match="Failed to write cell content collaboratively"):
-            await write_to_cell_collaboratively(self.mock_ynotebook, self.mock_ycell, "new content")
+        with pytest.raises(RuntimeError):
+            await write_to_cell_collaboratively(
+                self.mock_ynotebook, self.mock_ycell, "new content", animate=True
+            )
 
     @pytest.mark.asyncio
     @patch("jupyter_ai_tools.toolkits.notebook._safe_set_cursor")
@@ -112,14 +117,14 @@ class TestWriteToCellCollaboratively:
     async def test_delete_operation_called(
         self, mock_sequence_matcher, mock_delete_op, mock_safe_set_cursor
     ):
-        """Test that delete operation is called for delete opcodes."""
+        """Test that delete operation is called for delete opcodes (animated path)."""
         mock_sm = Mock()
         mock_sm.get_opcodes.return_value = [("delete", 0, 5, 0, 0)]
         mock_sequence_matcher.return_value = mock_sm
         mock_delete_op.return_value = None
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content"
+            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
         )
 
         assert result is True
@@ -132,14 +137,14 @@ class TestWriteToCellCollaboratively:
     async def test_insert_operation_called(
         self, mock_sequence_matcher, mock_insert_op, mock_safe_set_cursor
     ):
-        """Test that insert operation is called for insert opcodes."""
+        """Test that insert operation is called for insert opcodes (animated path)."""
         mock_sm = Mock()
         mock_sm.get_opcodes.return_value = [("insert", 0, 0, 0, 5)]
         mock_sequence_matcher.return_value = mock_sm
         mock_insert_op.return_value = 5
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content"
+            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
         )
 
         assert result is True
@@ -152,14 +157,14 @@ class TestWriteToCellCollaboratively:
     async def test_replace_operation_called(
         self, mock_sequence_matcher, mock_replace_op, mock_safe_set_cursor
     ):
-        """Test that replace operation is called for replace opcodes."""
+        """Test that replace operation is called for replace opcodes (animated path)."""
         mock_sm = Mock()
         mock_sm.get_opcodes.return_value = [("replace", 0, 5, 0, 7)]
         mock_sequence_matcher.return_value = mock_sm
         mock_replace_op.return_value = 7
 
         result = await write_to_cell_collaboratively(
-            self.mock_ynotebook, self.mock_ycell, "new content"
+            self.mock_ynotebook, self.mock_ycell, "new content", animate=True
         )
 
         assert result is True
@@ -321,37 +326,34 @@ class TestSafeSetCursor:
 
 
 class TestIntegration:
-    """Integration tests for the complete functionality."""
+    """Integration tests for the animated path (animate=True)."""
 
     @pytest.mark.asyncio
     @patch("jupyter_ai_tools.toolkits.notebook.set_cursor_in_ynotebook")
     @patch("jupyter_ai_tools.toolkits.notebook.asyncio.sleep")
     async def test_full_workflow_simple_change(self, mock_sleep, mock_set_cursor):
-        """Test a complete workflow with simple text change."""
+        """Test a complete workflow with simple text change (animated path)."""
         mock_ynotebook = Mock()
         mock_ycell = MagicMock()
         mock_source = MagicMock()
 
-        # Set up mocks
         mock_ycell.to_py.return_value = {"source": "hello"}
         mock_ycell.__getitem__.return_value = mock_source
         mock_source.insert = Mock()
         mock_source.__delitem__ = Mock()
 
-        # This should result in a replace operation: "hello" -> "world"
         result = await write_to_cell_collaboratively(
-            mock_ynotebook, mock_ycell, "world", typing_speed=0.0
+            mock_ynotebook, mock_ycell, "world", typing_speed=0.0, animate=True
         )
 
         assert result is True
-        # Should have called insert operations for typing simulation
         mock_source.insert.assert_called()
 
     @pytest.mark.asyncio
     @patch("jupyter_ai_tools.toolkits.notebook.set_cursor_in_ynotebook")
     @patch("jupyter_ai_tools.toolkits.notebook.asyncio.sleep")
     async def test_custom_typing_speed(self, mock_sleep, mock_set_cursor):
-        """Test that custom typing speed is respected."""
+        """Test that custom typing speed is respected (animated path)."""
         mock_ynotebook = Mock()
         mock_ycell = MagicMock()
         mock_source = MagicMock()
@@ -360,13 +362,107 @@ class TestIntegration:
         mock_ycell.__getitem__.return_value = mock_source
         mock_source.insert = Mock()
 
-        await write_to_cell_collaboratively(mock_ynotebook, mock_ycell, "test", typing_speed=0.5)
+        await write_to_cell_collaboratively(
+            mock_ynotebook, mock_ycell, "test", typing_speed=0.5, animate=True
+        )
 
-        # Should have called sleep with custom timing
         mock_sleep.assert_called()
-        # At least one call should use our custom typing speed
         sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
         assert 0.5 in sleep_calls
+
+
+class TestAtomicReplace:
+    """Tests for the default atomic replace path (animate=False)."""
+
+    def setup_method(self):
+        self.mock_ynotebook = Mock()
+        self.mock_ycell = MagicMock()
+        self.mock_source = MagicMock()
+        self.mock_ycell.to_py.return_value = {"source": "old content"}
+        self.mock_ycell.__getitem__.return_value = self.mock_source
+        self.mock_source.insert = Mock()
+        self.mock_source.__delitem__ = Mock()
+
+    @pytest.mark.asyncio
+    async def test_atomic_replace_calls_delete_then_insert(self):
+        """del[0:len(old)] then insert(0, new) — correct args."""
+        result = await write_to_cell_collaboratively(
+            self.mock_ynotebook, self.mock_ycell, "new content"
+        )
+        assert result is True
+        self.mock_source.__delitem__.assert_called_once_with(slice(0, len("old content")))
+        self.mock_source.insert.assert_called_once_with(0, "new content")
+
+    @pytest.mark.asyncio
+    async def test_no_asyncio_sleep_called(self):
+        """No event loop yields between CRDT ops — the race condition fix."""
+        with patch("jupyter_ai_tools.toolkits.notebook.asyncio.sleep") as mock_sleep:
+            await write_to_cell_collaboratively(
+                self.mock_ynotebook, self.mock_ycell, "new content"
+            )
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_real_pycrdt_replace(self):
+        """Correct final content with real YText."""
+        pycrdt = pytest.importorskip("pycrdt")
+        doc = pycrdt.Doc()
+        source_text = doc.get("source", type=pycrdt.Text)
+        source_text += "old content"
+
+        mock_ycell = MagicMock()
+        mock_ycell.to_py.return_value = {"source": "old content"}
+        mock_ycell.__getitem__.return_value = source_text
+
+        result = await write_to_cell_collaboratively(Mock(), mock_ycell, "new content")
+
+        assert result is True
+        assert str(source_text) == "new content"
+
+    @pytest.mark.asyncio
+    async def test_atomic_replace_from_empty_cell(self):
+        """Write into a blank cell — del[0:0] is a no-op but insert must still run."""
+        self.mock_ycell.to_py.return_value = {"source": ""}
+        result = await write_to_cell_collaboratively(
+            self.mock_ynotebook, self.mock_ycell, "hello"
+        )
+        assert result is True
+        self.mock_source.__delitem__.assert_called_once_with(slice(0, 0))
+        self.mock_source.insert.assert_called_once_with(0, "hello")
+
+    @pytest.mark.asyncio
+    async def test_atomic_replace_to_empty_cell(self):
+        """Clear a cell — delete runs, insert is called with empty string."""
+        result = await write_to_cell_collaboratively(
+            self.mock_ynotebook, self.mock_ycell, ""
+        )
+        assert result is True
+        self.mock_source.__delitem__.assert_called_once_with(slice(0, len("old content")))
+        self.mock_source.insert.assert_called_once_with(0, "")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_modification_does_not_panic(self):
+        """Concurrent CRDT modification must not cause a Rust panic (the original crash)."""
+        import asyncio as _asyncio
+        pycrdt = pytest.importorskip("pycrdt")
+        doc = pycrdt.Doc()
+        source_text = doc.get("source", type=pycrdt.Text)
+        source_text += "hello world " * 10
+
+        mock_ycell = MagicMock()
+        mock_ycell.to_py.return_value = {"source": str(source_text)}
+        mock_ycell.__getitem__.return_value = source_text
+
+        async def concurrent_clear():
+            await _asyncio.sleep(0)
+            current = str(source_text)
+            if current:
+                del source_text[0:len(current)]
+
+        await _asyncio.gather(
+            write_to_cell_collaboratively(Mock(), mock_ycell, "replacement"),
+            concurrent_clear(),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_write_to_cell_collaboratively.py
+++ b/tests/test_write_to_cell_collaboratively.py
@@ -366,68 +366,47 @@ class TestIntegration:
 
 
 class TestAtomicReplace:
-    """Tests for the default atomic replace path (animate=True)."""
+    """Tests for _atomic_replace_cell_source."""
 
-    def setup_method(self):
-        self.mock_ynotebook = Mock()
-        self.mock_ycell = MagicMock()
-        self.mock_source = MagicMock()
-        self.mock_ycell.to_py.return_value = {"source": "old content"}
-        self.mock_ycell.__getitem__.return_value = self.mock_source
-        self.mock_source.insert = Mock()
-        self.mock_source.__delitem__ = Mock()
+    def _make_ycell(self, initial: str):
+        """Return (mock_ycell, source_text) backed by real pycrdt."""
+        pycrdt = pytest.importorskip("pycrdt")
+        doc = pycrdt.Doc()
+        source_text = doc.get("source", type=pycrdt.Text)
+        source_text += initial
+        mock_ycell = MagicMock()
+        mock_ycell.to_py.return_value = {"source": initial}
+        mock_ycell.__getitem__.return_value = source_text
+        return mock_ycell, source_text
 
-    def test_atomic_replace_calls_clear_then_insert(self):
-        """clear() then insert(0, new) — correct ops."""
-        _atomic_replace_cell_source(self.mock_ycell, "new content")
-        self.mock_source.clear.assert_called_once()
-        self.mock_source.insert.assert_called_once_with(0, "new content")
+    def test_replaces_content(self):
+        """Old content is fully replaced by new content."""
+        mock_ycell, source_text = self._make_ycell("old content")
+        _atomic_replace_cell_source(mock_ycell, "new content")
+        assert str(source_text) == "new content"
+
+    def test_from_empty_cell(self):
+        """Writing into a blank cell produces correct output."""
+        mock_ycell, source_text = self._make_ycell("")
+        _atomic_replace_cell_source(mock_ycell, "hello")
+        assert str(source_text) == "hello"
+
+    def test_to_empty_cell(self):
+        """Clearing a cell leaves it empty."""
+        mock_ycell, source_text = self._make_ycell("old content")
+        _atomic_replace_cell_source(mock_ycell, "")
+        assert str(source_text) == ""
 
     def test_no_asyncio_sleep_called(self):
         """No event loop yields between CRDT ops — the race condition fix."""
+        mock_ycell, _ = self._make_ycell("old")
         with patch("jupyter_ai_tools.toolkits.notebook.asyncio.sleep") as mock_sleep:
-            _atomic_replace_cell_source(self.mock_ycell, "new content")
+            _atomic_replace_cell_source(mock_ycell, "new")
         mock_sleep.assert_not_called()
-
-    def test_real_pycrdt_replace(self):
-        """Correct final content with real YText."""
-        pycrdt = pytest.importorskip("pycrdt")
-        doc = pycrdt.Doc()
-        source_text = doc.get("source", type=pycrdt.Text)
-        source_text += "old content"
-
-        mock_ycell = MagicMock()
-        mock_ycell.to_py.return_value = {"source": "old content"}
-        mock_ycell.__getitem__.return_value = source_text
-
-        _atomic_replace_cell_source(mock_ycell, "new content")
-
-        assert str(source_text) == "new content"
-
-    def test_atomic_replace_from_empty_cell(self):
-        """Write into a blank cell — clear is a no-op but insert must still run."""
-        self.mock_ycell.to_py.return_value = {"source": ""}
-        _atomic_replace_cell_source(self.mock_ycell, "hello")
-        self.mock_source.clear.assert_called_once()
-        self.mock_source.insert.assert_called_once_with(0, "hello")
-
-    def test_atomic_replace_to_empty_cell(self):
-        """Clear a cell — clear runs, insert is called with empty string."""
-        _atomic_replace_cell_source(self.mock_ycell, "")
-        self.mock_source.clear.assert_called_once()
-        self.mock_source.insert.assert_called_once_with(0, "")
 
     def test_no_panic_on_real_ytext(self):
         """Atomic replace on real YText never panics regardless of content size."""
-        pycrdt = pytest.importorskip("pycrdt")
-        doc = pycrdt.Doc()
-        source_text = doc.get("source", type=pycrdt.Text)
-        source_text += "hello world " * 10
-
-        mock_ycell = MagicMock()
-        mock_ycell.to_py.return_value = {"source": str(source_text)}
-        mock_ycell.__getitem__.return_value = source_text
-
+        mock_ycell, source_text = self._make_ycell("hello world " * 10)
         _atomic_replace_cell_source(mock_ycell, "replacement")
         assert str(source_text) == "replacement"
 


### PR DESCRIPTION
Fixes #22 

## Problem

`write_to_cell_collaboratively` uses `difflib.SequenceMatcher` to compute character-level diffs and applies them one operation at a time to a collaborative document text (`pycrdt.Text`) object. For each delete opcode, `_handle_delete_operation` does:
```
_safe_set_cursor(...)             # highlight text to be deleted
await asyncio.sleep(min(0.3, typing_speed*3)) # ← yields to event loop
del cell_source[cursor_position:cursor_position+delete_length] # ← crash
```
As you can see await yields to the asyncio event loop. Any coroutine that runs during the 0.3s window like a Y.js sync from another user, edit_cell call, an nb-cli tab can modify the same cell. When the sleep resumes, if the cell is now shorter, the delete is out of bounds and panics in pycrdt’s Rust layer https://github.com/y-crdt/y-crdt/blob/v0.25.0/yrs/src/types/text.rs#L845:
```
thread '<unnamed>' panicked at yrs-0.25.0/src/types/text.rs:845:
Couldn't remove 1 elements from an array. Only 0 of them were successfully removed.
pyo3_runtime.PanicException: Couldn't remove 1 elements from an array
```

## Proposed solution 

Replace the default write path with an atomic replace, delete old content and insert new with no `await` between CRDT ops. Preserve the typing animation behind an `animate=True` flag for consumers that rely on it.


## Testing

Standalone (no server needed): run script below
```python
import asyncio, pycrdt

async def slow_delete(text, pos, n):
    await asyncio.sleep(0.1)
    del text[pos:pos+n]  # panics if content modified during sleep

async def concurrent_clear(text, delay):
    await asyncio.sleep(delay)
    del text[0:len(str(text))]

async def main():
    doc = pycrdt.Doc()
    text = doc.get("source", type=pycrdt.Text)
    text += "hello world " * 10
    await asyncio.gather(
        slow_delete(text, pos=100, n=5),
        concurrent_clear(text, delay=0.05),
    )

asyncio.run(main())
# pyo3_runtime.PanicException: Couldn't remove 5 elements from an array
```

**With JupyterLab + agent:**

1. Create a notebook with one large cell (~100 lines, the more the better)
2. Ask an agent with `edit_cell` tool access to rewrite the cell with completely different content
3. The moment `edit_cell` appears in the agent's tool calls, fire in a second terminal:
```bash
for i in {1..10}; do
  nb cell update notebook.ipynb --cell-index 0 --source "# race $i" \
    --server http://localhost:8888 --token <token> &
done
wait
```
4. Check server logs for the panic. Cells with large diffs hit it more reliably
