### PR TITLE
Add read_cell_image tool for surfacing cell images to multimodal models

### DIFF
--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -385,7 +385,7 @@ async def read_cell_image(
         ) from e
 
     cell, _ = await read_cell_json(file_path, cell_id)
-    outputs = cell.get("outputs", []) or []
+    outputs = cell.get("outputs") or []
 
     if output_index is not None:
         if not 0 <= output_index < len(outputs):

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -2,12 +2,14 @@ import asyncio
 import difflib
 from functools import lru_cache
 import json
+import logging
 import os
 import re
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import nbformat
 from jupyter_ydoc import YNotebook
+from mcp.types import ImageContent
 from pycrdt import Assoc, Text
 
 from ..utils import (
@@ -18,6 +20,8 @@ from ..utils import (
     normalize_filepath,
     notebook_json_to_md,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _is_uuid_like(value: str) -> bool:
@@ -307,6 +311,86 @@ async def read_cell_json(file_path: str, cell_id: str) -> Tuple[Dict[str, Any], 
 
     except Exception:
         raise
+
+
+async def read_cell_image(
+    file_path: str,
+    cell_id: str,
+    output_index: Optional[int] = None,
+) -> Optional[ImageContent]:
+    """Returns a single image from a cell's outputs as an MCP ImageContent.
+
+    This function reads a specific cell from a Jupyter notebook file and returns
+    the first supported image found in the cell's outputs (typically a matplotlib
+    plot or other rich display_data). The image is returned as MCP ImageContent
+    so multimodal clients can view it directly.
+
+    The base64 payload stored in the .ipynb JSON is passed through unchanged;
+    no decode/re-encode round-trip is performed.
+
+    Args:
+        file_path:
+            The relative path to the notebook file on the filesystem.
+        cell_id:
+            The UUID of the cell to read, or a numeric index as string.
+        output_index:
+            If provided, inspect only that single output. If None (default),
+            scan all outputs and return the first supported image found.
+
+    Returns:
+        An `ImageContent` for the first image/png, image/jpeg, or image/gif
+        found, or None if no supported image is present.
+
+        image/svg+xml is intentionally skipped — most multimodal providers do
+        not accept SVG as image input. TODO: rasterize SVG to PNG, or return
+        the raw XML as text.
+
+    Raises:
+        LookupError: If no cell with the given ID is found.
+        IndexError: If output_index is provided but is out of range for the
+            cell's outputs.
+    """
+    cell, _ = await read_cell_json(file_path, cell_id)
+    outputs = cell.get("outputs", []) or []
+
+    if output_index is not None:
+        if not 0 <= output_index < len(outputs):
+            raise IndexError(
+                f"output_index {output_index} out of range "
+                f"(cell has {len(outputs)} outputs)"
+            )
+        candidates = [outputs[output_index]]
+    else:
+        candidates = outputs
+
+    supported_mime_types = ("image/png", "image/jpeg", "image/jpg", "image/gif")
+
+    for output in candidates:
+        if output.get("output_type") not in ("display_data", "execute_result"):
+            continue
+        data = output.get("data", {})
+        for mime_type in supported_mime_types:
+            if mime_type not in data:
+                continue
+            payload = data[mime_type]
+            # nbformat may store base64 as a list of strings or with trailing
+            # whitespace; normalize to a clean single string.
+            if isinstance(payload, list):
+                payload = "".join(payload)
+            payload = "".join(payload.split())
+            if mime_type == "image/gif":
+                logger.warning(
+                    "Returning image/gif from %s (cell_id=%s); multimodal "
+                    "provider support for GIFs is limited (e.g. Claude uses "
+                    "the first frame only, OpenAI may reject).",
+                    file_path,
+                    cell_id,
+                )
+            # Normalize the non-standard image/jpg alias to image/jpeg.
+            reported_mime = "image/jpeg" if mime_type == "image/jpg" else mime_type
+            return ImageContent(type="image", data=payload, mimeType=reported_mime)
+
+    return None
 
 
 async def get_cell_id_from_index(file_path: str, cell_index: int) -> str:

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -5,11 +5,10 @@ import json
 import logging
 import os
 import re
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 import nbformat
 from jupyter_ydoc import YNotebook
-from mcp.types import ImageContent
 from pycrdt import Assoc, Text
 
 from ..utils import (
@@ -20,6 +19,9 @@ from ..utils import (
     normalize_filepath,
     notebook_json_to_md,
 )
+
+if TYPE_CHECKING:
+    from mcp.types import ImageContent
 
 logger = logging.getLogger(__name__)
 
@@ -317,16 +319,38 @@ async def read_cell_image(
     file_path: str,
     cell_id: str,
     output_index: Optional[int] = None,
-) -> Optional[ImageContent]:
+) -> Optional["ImageContent"]:
     """Returns a single image from a cell's outputs as an MCP ImageContent.
 
-    This function reads a specific cell from a Jupyter notebook file and returns
-    the first supported image found in the cell's outputs (typically a matplotlib
-    plot or other rich display_data). The image is returned as MCP ImageContent
-    so multimodal clients can view it directly.
+    Reads a specific cell from a Jupyter notebook and returns the first
+    supported image found in its outputs (typically a matplotlib plot or other
+    rich display_data) as an ``mcp.types.ImageContent``. The base64 payload
+    already stored in the .ipynb JSON is passed through unchanged; no
+    decode/re-encode round-trip is performed.
 
-    The base64 payload stored in the .ipynb JSON is passed through unchanged;
-    no decode/re-encode round-trip is performed.
+    Why the ImageContent return type (and not a base64 string)
+    ----------------------------------------------------------
+    Multimodal LLMs route inputs through two separate channels:
+
+    * the **text channel**, which tokenizes text for the language model, and
+    * the **image channel**, which feeds bytes into a vision encoder.
+
+    A base64 string returned as plain text from an MCP tool lands in the text
+    channel — the model sees tens of thousands of opaque tokens, not a plot.
+    ``mcp.types.ImageContent`` is the protocol-level signal that tells the
+    consumer (e.g. jupyter-ai) "wire these bytes into the vision channel of
+    the downstream LLM call." Without it, returning the image is effectively
+    indistinguishable from returning nothing useful.
+
+    As a design aside: OpenAI's chat completions API accepts
+    ``data:image/png;base64,...`` URLs directly in ``image_url`` inputs, but
+    Claude and Gemini do not — their SDKs require explicit image content
+    blocks with separate data/media-type fields. Either way, the tool-result
+    boundary here is MCP, so ``ImageContent`` is the only correct return.
+
+    MCP is an optional extra of ``jupyter-ai-tools``. The import is lazy; if
+    the ``mcp`` package is not installed, calling this function raises a
+    clear ``RuntimeError`` pointing at ``pip install jupyter-ai-tools[mcp]``.
 
     Args:
         file_path:
@@ -338,7 +362,7 @@ async def read_cell_image(
             scan all outputs and return the first supported image found.
 
     Returns:
-        An `ImageContent` for the first image/png, image/jpeg, or image/gif
+        An ``ImageContent`` for the first image/png, image/jpeg, or image/gif
         found, or None if no supported image is present.
 
         image/svg+xml is intentionally skipped — most multimodal providers do
@@ -349,7 +373,17 @@ async def read_cell_image(
         LookupError: If no cell with the given ID is found.
         IndexError: If output_index is provided but is out of range for the
             cell's outputs.
+        RuntimeError: If the ``mcp`` package is not installed.
     """
+    try:
+        from mcp.types import ImageContent
+    except ImportError as e:
+        raise RuntimeError(
+            "read_cell_image requires the 'mcp' package. "
+            "Install it with: pip install jupyter-ai-tools[mcp]  "
+            "(or: pip install mcp)"
+        ) from e
+
     cell, _ = await read_cell_json(file_path, cell_id)
     outputs = cell.get("outputs", []) or []
 

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -322,6 +322,10 @@ async def read_cell_image(
 ) -> Optional["ImageContent"]:
     """Returns a single image from a cell's outputs as an MCP ImageContent.
 
+    Returns the first supported image found. Use ``output_index`` to access a
+    specific output. Use ``read_cell`` to discover the cell's outputs (note:
+    image outputs are not yet enumerated there — see issue #27).
+
     Reads a specific cell from a Jupyter notebook and returns the first
     supported image found in its outputs (typically a matplotlib plot or other
     rich display_data) as an ``mcp.types.ImageContent``. The base64 payload
@@ -397,7 +401,7 @@ async def read_cell_image(
     else:
         candidates = outputs
 
-    supported_mime_types = ("image/png", "image/jpeg", "image/jpg", "image/gif")
+    supported_mime_types = ("image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp")
 
     for output in candidates:
         if output.get("output_type") not in ("display_data", "execute_result"):
@@ -422,6 +426,7 @@ async def read_cell_image(
                 )
             # Normalize the non-standard image/jpg alias to image/jpeg.
             reported_mime = "image/jpeg" if mime_type == "image/jpg" else mime_type
+            # NOTE: Returns on first match. Multi-image support tracked in issue #27.
             return ImageContent(type="image", data=payload, mimeType=reported_mime)
 
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "jupyterlab_git",
   "pycrdt>=0.12.0,<0.13.0",
   "jupyter_ydoc>=3.0.0,<4.0.0",
+  "mcp>=1.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ dependencies = [
   "jupyterlab_git",
   "pycrdt>=0.12.0,<0.13.0",
   "jupyter_ydoc>=3.0.0,<4.0.0",
-  "mcp>=1.0",
 ]
 
 
 [project.optional-dependencies]
-test = ["pytest>=7.0", "pytest-jupyter[server]>=0.6", "pytest-asyncio"]
+mcp = ["mcp>=1.0"]
+test = ["pytest>=7.0", "pytest-jupyter[server]>=0.6", "pytest-asyncio", "mcp>=1.0"]
 lint = [
   "black>=22.6.0",
   "ruff>=0.0.156",

--- a/tests/test_read_cell_image.py
+++ b/tests/test_read_cell_image.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -236,3 +237,19 @@ async def test_base64_list_payload_is_joined(notebook_path):
 
     assert isinstance(result, ImageContent)
     assert base64.b64decode(result.data) == b"list-payload"
+
+
+@pytest.mark.asyncio
+async def test_raises_runtime_error_when_mcp_is_missing(notebook_path):
+    """When the optional mcp dep is not installed, surface a clear error."""
+    removed = {
+        name: sys.modules.pop(name)
+        for name in list(sys.modules)
+        if name == "mcp" or name.startswith("mcp.")
+    }
+    try:
+        with patch.dict(sys.modules, {"mcp": None, "mcp.types": None}):
+            with pytest.raises(RuntimeError, match="jupyter-ai-tools\\[mcp\\]"):
+                await read_cell_image(notebook_path, PNG_CELL_ID)
+    finally:
+        sys.modules.update(removed)

--- a/tests/test_read_cell_image.py
+++ b/tests/test_read_cell_image.py
@@ -15,6 +15,7 @@ PNG_CELL_ID = "11111111-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
 JPEG_CELL_ID = "22222222-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
 JPG_CELL_ID = "33333333-cccc-4ccc-cccc-cccccccccccc"
 GIF_CELL_ID = "44444444-dddd-4ddd-dddd-dddddddddddd"
+WEBP_CELL_ID = "bbbbbbbb-5555-4555-5555-555555555555"
 SVG_CELL_ID = "55555555-eeee-4eee-eeee-eeeeeeeeeeee"
 TEXT_ONLY_CELL_ID = "66666666-ffff-4fff-ffff-ffffffffffff"
 MULTI_OUTPUT_CELL_ID = "77777777-1111-4111-1111-111111111111"
@@ -70,6 +71,7 @@ def _build_notebook() -> dict:
             _cell(JPEG_CELL_ID, [_image_output("image/jpeg", _b64(b"fake-jpeg-bytes"))]),
             _cell(JPG_CELL_ID, [_image_output("image/jpg", _b64(b"fake-jpg-bytes"))]),
             _cell(GIF_CELL_ID, [_image_output("image/gif", _b64(b"fake-gif-bytes"))]),
+            _cell(WEBP_CELL_ID, [_image_output("image/webp", _b64(b"fake-webp-bytes"))]),
             _cell(
                 SVG_CELL_ID,
                 [
@@ -160,6 +162,15 @@ async def test_returns_gif_and_logs_warning(notebook_path, caplog):
     assert result.mimeType == "image/gif"
     assert base64.b64decode(result.data) == b"fake-gif-bytes"
     assert any("image/gif" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_returns_webp_image_content(notebook_path):
+    result = await read_cell_image(notebook_path, WEBP_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    assert result.mimeType == "image/webp"
+    assert base64.b64decode(result.data) == b"fake-webp-bytes"
 
 
 @pytest.mark.asyncio

--- a/tests/test_read_cell_image.py
+++ b/tests/test_read_cell_image.py
@@ -1,0 +1,238 @@
+import base64
+import json
+import logging
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.types import ImageContent
+
+from jupyter_ai_tools.toolkits.notebook import read_cell_image
+
+PNG_CELL_ID = "11111111-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+JPEG_CELL_ID = "22222222-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+JPG_CELL_ID = "33333333-cccc-4ccc-cccc-cccccccccccc"
+GIF_CELL_ID = "44444444-dddd-4ddd-dddd-dddddddddddd"
+SVG_CELL_ID = "55555555-eeee-4eee-eeee-eeeeeeeeeeee"
+TEXT_ONLY_CELL_ID = "66666666-ffff-4fff-ffff-ffffffffffff"
+MULTI_OUTPUT_CELL_ID = "77777777-1111-4111-1111-111111111111"
+STREAM_ONLY_CELL_ID = "88888888-2222-4222-2222-222222222222"
+WHITESPACE_CELL_ID = "99999999-3333-4333-3333-333333333333"
+LIST_PAYLOAD_CELL_ID = "aaaaaaaa-4444-4444-4444-444444444444"
+
+
+def _b64(payload: bytes) -> str:
+    return base64.b64encode(payload).decode()
+
+
+def _image_output(mime_type: str, payload):
+    return {
+        "output_type": "display_data",
+        "data": {mime_type: payload, "text/plain": ["<Figure>"]},
+        "metadata": {},
+    }
+
+
+def _text_output():
+    return {
+        "output_type": "execute_result",
+        "execution_count": 1,
+        "data": {"text/plain": ["42"]},
+        "metadata": {},
+    }
+
+
+def _stream_output():
+    return {
+        "output_type": "stream",
+        "name": "stdout",
+        "text": "hello\n",
+    }
+
+
+def _cell(cell_id: str, outputs):
+    return {
+        "cell_type": "code",
+        "execution_count": 1,
+        "id": cell_id,
+        "metadata": {},
+        "source": "",
+        "outputs": outputs,
+    }
+
+
+def _build_notebook() -> dict:
+    return {
+        "cells": [
+            _cell(PNG_CELL_ID, [_image_output("image/png", _b64(b"fake-png-bytes"))]),
+            _cell(JPEG_CELL_ID, [_image_output("image/jpeg", _b64(b"fake-jpeg-bytes"))]),
+            _cell(JPG_CELL_ID, [_image_output("image/jpg", _b64(b"fake-jpg-bytes"))]),
+            _cell(GIF_CELL_ID, [_image_output("image/gif", _b64(b"fake-gif-bytes"))]),
+            _cell(
+                SVG_CELL_ID,
+                [
+                    {
+                        "output_type": "display_data",
+                        "data": {"image/svg+xml": "<svg/>", "text/plain": ["<Figure>"]},
+                        "metadata": {},
+                    }
+                ],
+            ),
+            _cell(TEXT_ONLY_CELL_ID, [_text_output()]),
+            _cell(
+                MULTI_OUTPUT_CELL_ID,
+                [
+                    _text_output(),
+                    _image_output("image/png", _b64(b"multi-first-png")),
+                    _image_output("image/png", _b64(b"multi-second-png")),
+                ],
+            ),
+            _cell(STREAM_ONLY_CELL_ID, [_stream_output()]),
+            _cell(
+                WHITESPACE_CELL_ID,
+                [_image_output("image/png", _b64(b"whitespace-png") + "\n  \n")],
+            ),
+            _cell(
+                LIST_PAYLOAD_CELL_ID,
+                [
+                    _image_output(
+                        "image/png",
+                        [_b64(b"list-payload")[:5], _b64(b"list-payload")[5:]],
+                    )
+                ],
+            ),
+        ],
+        "metadata": {"language_info": {"name": "python"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+@pytest.fixture
+def notebook_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        nb_path = Path(temp_dir) / "nb.ipynb"
+        nb_path.write_text(json.dumps(_build_notebook()))
+
+        with patch("jupyter_ai_tools.utils.get_serverapp") as mock_serverapp:
+            mock_app = MagicMock()
+            mock_app.root_dir = temp_dir
+            mock_serverapp.return_value = mock_app
+            yield str(nb_path)
+
+
+@pytest.mark.asyncio
+async def test_returns_png_image_content(notebook_path):
+    result = await read_cell_image(notebook_path, PNG_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    assert result.type == "image"
+    assert result.mimeType == "image/png"
+    assert base64.b64decode(result.data) == b"fake-png-bytes"
+
+
+@pytest.mark.asyncio
+async def test_returns_jpeg_image_content(notebook_path):
+    result = await read_cell_image(notebook_path, JPEG_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    assert result.mimeType == "image/jpeg"
+    assert base64.b64decode(result.data) == b"fake-jpeg-bytes"
+
+
+@pytest.mark.asyncio
+async def test_normalizes_jpg_alias_to_jpeg(notebook_path):
+    result = await read_cell_image(notebook_path, JPG_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    assert result.mimeType == "image/jpeg"
+    assert base64.b64decode(result.data) == b"fake-jpg-bytes"
+
+
+@pytest.mark.asyncio
+async def test_returns_gif_and_logs_warning(notebook_path, caplog):
+    with caplog.at_level(logging.WARNING, logger="jupyter_ai_tools.toolkits.notebook"):
+        result = await read_cell_image(notebook_path, GIF_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    assert result.mimeType == "image/gif"
+    assert base64.b64decode(result.data) == b"fake-gif-bytes"
+    assert any("image/gif" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_svg_returns_none(notebook_path):
+    # TODO: when SVG handling is added, update this test accordingly.
+    result = await read_cell_image(notebook_path, SVG_CELL_ID)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_text_only_output_returns_none(notebook_path):
+    result = await read_cell_image(notebook_path, TEXT_ONLY_CELL_ID)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_stream_only_output_returns_none(notebook_path):
+    result = await read_cell_image(notebook_path, STREAM_ONLY_CELL_ID)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_scans_all_outputs_and_returns_first_image(notebook_path):
+    # First output is text, second is the "earlier" PNG — should pick that one.
+    result = await read_cell_image(notebook_path, MULTI_OUTPUT_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    assert base64.b64decode(result.data) == b"multi-first-png"
+
+
+@pytest.mark.asyncio
+async def test_output_index_selects_specific_output(notebook_path):
+    result = await read_cell_image(notebook_path, MULTI_OUTPUT_CELL_ID, output_index=2)
+
+    assert isinstance(result, ImageContent)
+    assert base64.b64decode(result.data) == b"multi-second-png"
+
+
+@pytest.mark.asyncio
+async def test_output_index_skips_non_image_output_returns_none(notebook_path):
+    result = await read_cell_image(notebook_path, MULTI_OUTPUT_CELL_ID, output_index=0)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_output_index_out_of_range_raises(notebook_path):
+    with pytest.raises(IndexError):
+        await read_cell_image(notebook_path, PNG_CELL_ID, output_index=99)
+
+
+@pytest.mark.asyncio
+async def test_missing_cell_raises_lookup_error(notebook_path):
+    with pytest.raises(LookupError):
+        await read_cell_image(notebook_path, "deadbeef-0000-4000-8000-000000000000")
+
+
+@pytest.mark.asyncio
+async def test_base64_whitespace_is_stripped(notebook_path):
+    result = await read_cell_image(notebook_path, WHITESPACE_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    # No whitespace in the stored payload.
+    assert result.data == result.data.strip()
+    assert "\n" not in result.data and " " not in result.data
+    assert base64.b64decode(result.data) == b"whitespace-png"
+
+
+@pytest.mark.asyncio
+async def test_base64_list_payload_is_joined(notebook_path):
+    result = await read_cell_image(notebook_path, LIST_PAYLOAD_CELL_ID)
+
+    assert isinstance(result, ImageContent)
+    assert base64.b64decode(result.data) == b"list-payload"


### PR DESCRIPTION
## Summary

The existing `read_cell` / `read_notebook` tools silently drop image outputs — see `jupyter_ai_tools/utils.py::format_outputs`: `# TODO: Add other mime types` — so matplotlib plots and any other rich `display_data` images are invisible to multimodal models. `read_notebook_cells` does extract image data but returns it as a JSON dict, which serializes as `TextContent` and isn't rendered as an image by MCP-aware clients.

This PR adds a dedicated `read_cell_image(file_path, cell_id, output_index=None)` tool that reads the base64 payload straight out of the notebook JSON (nbformat already stores it base64-encoded) and returns it as an `mcp.types.ImageContent`. No decode/re-encode round-trip.

## Why `ImageContent` and not a plain base64 string

Multimodal LLMs route inputs through two separate channels — the **text channel** (tokenizer) and the **image channel** (vision encoder). A base64 string returned as plain text lands in the text channel and gets tokenized as tens of thousands of opaque tokens, not rendered as an image. Empirically verified with FastMCP: a `dict` shaped like `ImageContent` is JSON-serialized to `TextContent`, not auto-wrapped. Only returning a typed `mcp.types.ImageContent` (or `fastmcp.utilities.types.Image`) produces an actual image content block.

As a design aside: OpenAI's chat completions API accepts `data:image/png;base64,...` URLs in `image_url` inputs, but Claude and Gemini require explicit image blocks with separate data/media-type fields. Either way, the tool-result boundary here is MCP, so `ImageContent` is the correct return.

## Dep strategy

`mcp` is added as a new `[mcp]` optional-dependency extra, not a top-level runtime dep. The module-level import stays MCP-agnostic (matches every other tool in the package, which returns plain Python types); `mcp.types.ImageContent` is imported lazily inside `read_cell_image` itself, gated behind a `TYPE_CHECKING` import for the annotation. If `mcp` is not installed at call time, the function raises a clear `RuntimeError` pointing at `pip install jupyter-ai-tools[mcp]`.

In the normal install path (`jupyter-ai` → `jupyter-server-mcp` → `fastmcp` → `mcp`), `mcp` is already present transitively, so this is a no-op for real users. Standalone users of `jupyter-ai-tools` who don't need image fetching pay nothing.

## Behavior

- **PNG, JPEG**: returned as `ImageContent`. `image/jpg` is normalized to `image/jpeg`.
- **GIF**: returned with a `logger.warning(...)` — multimodal provider support for GIFs is inconsistent (Claude uses first frame only, OpenAI may reject).
- **SVG**: intentionally skipped (returns `None`) with a `TODO` to rasterize or return as text later. Most providers don't accept SVG as image input.
- **No image in cell / text-only / stream-only output**: returns `None`.
- **Missing cell**: raises `LookupError` (consistent with `read_cell_json`).
- **`output_index` out of range**: raises `IndexError`.
- **`mcp` not installed**: raises `RuntimeError` with install hint.
- **Size limits**: left to provider-side enforcement.

Also normalizes base64 payloads that are stored as list-of-strings or contain trailing whitespace (both appear in the wild).

## Companion change needed

Register `jupyter_ai_tools.toolkits.notebook:read_cell_image` in `jupyter-ai`'s `DEFAULT_JUPYTER_SERVER_MCP_TOOLS` list to expose it over MCP. Happy to open that PR once this lands.

## Test plan

- [x] 15 tests in `tests/test_read_cell_image.py` covering PNG, JPEG, `image/jpg` normalization, GIF warning logging, SVG-returns-None, text-only, stream-only, multi-output scanning, explicit `output_index`, out-of-range, missing-cell, whitespace stripping, list-payload joining, **and the RuntimeError when `mcp` is absent from `sys.modules`**.
- [x] Full suite passes locally (86/86).
- [x] `ruff check` introduces zero new violations vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)