### PR TITLE
feat: support editing cell type on edit cell

### DIFF
--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+from uuid import uuid4
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 import nbformat
@@ -1234,13 +1235,22 @@ async def select_cell(cell_id: str, username: Optional[str] = None) -> dict:
         raise
 
 
-async def edit_cell(file_path: str, cell_id: str, content: str, animate: bool = False) -> None:
-    """Edits the content of a notebook cell with the specified ID
+async def edit_cell(
+    file_path: str,
+    cell_id: str,
+    content: Optional[str] = None,
+    cell_type: Optional[Literal["code", "markdown", "raw"]] = None,
+    animate: bool = False,
+) -> None:
+    """Edits the content and/or type of a notebook cell with the specified ID.
 
-    This function modifies the content of a cell in a Jupyter notebook. It first attempts to use
+    This function modifies a cell in a Jupyter notebook. It first attempts to use
     the in-memory YDoc representation if the notebook is currently active. If the
     notebook is not active, it falls back to using the filesystem to read, modify,
     and write the notebook file directly using nbformat.
+
+    When changing cell type, the cell is replaced via ``set_cell()`` to ensure
+    type-specific fields (outputs, execution_count) are correctly added or removed.
 
     Args:
         file_path:
@@ -1248,7 +1258,11 @@ async def edit_cell(file_path: str, cell_id: str, content: str, animate: bool = 
         cell_id:
             The UUID of the cell to edit, or a numeric index as string.
         content:
-            The new content for the cell. If None, the cell content remains unchanged.
+            The new content for the cell. If None, the existing content is preserved.
+        cell_type:
+            The new cell type ("code", "markdown", "raw"). If None, the type is unchanged.
+        animate:
+            If True, simulate collaborative typing when changing content.
 
     Returns:
         None
@@ -1266,25 +1280,72 @@ async def edit_cell(file_path: str, cell_id: str, content: str, animate: bool = 
 
         if ydoc:
             cell_index = _get_cell_index_from_id_ydoc(ydoc, resolved_cell_id)
-            if cell_index is not None:
-                ycell = ydoc._ycells[cell_index]
-                if animate:
-                    await write_to_cell_collaboratively(ydoc, ycell, content)
-                else:
-                    _atomic_replace_cell_source(ycell, content)
-            else:
+            if cell_index is None:
                 raise ValueError(f"Cell with {cell_id=} not found in notebook")
+
+            ycell = ydoc._ycells[cell_index]
+            old_cell = ycell.to_py()
+            old_type = old_cell.get("cell_type")
+            needs_type_change = cell_type is not None and cell_type != old_type
+            source = content if content is not None else old_cell.get("source", "")
+
+            if needs_type_change:
+                new_cell = {
+                    "cell_type": cell_type,
+                    "source": source,
+                    "id": old_cell.get("id", str(uuid4())),
+                    "metadata": old_cell.get("metadata", {}),
+                }
+                if cell_type == "code":
+                    new_cell["outputs"] = []
+                    new_cell["execution_count"] = None
+                ydoc.set_cell(cell_index, new_cell)
+                if animate and content is not None:
+                    # After replacement, write content collaboratively on the new ycell
+                    new_ycell = ydoc._ycells[cell_index]
+                    _atomic_replace_cell_source(new_ycell, "")
+                    await write_to_cell_collaboratively(ydoc, new_ycell, source)
+            else:
+                if content is not None:
+                    if animate:
+                        await write_to_cell_collaboratively(ydoc, ycell, content)
+                    else:
+                        _atomic_replace_cell_source(ycell, content)
         else:
             with open(file_path, "r", encoding="utf-8") as f:
                 notebook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
 
             cell_index = _get_cell_index_from_id_nbformat(notebook, resolved_cell_id)
-            if cell_index is not None:
-                notebook.cells[cell_index].source = content
+            if cell_index is None:
+                raise ValueError(f"Cell with {cell_id=} not found in notebook at {file_path=}")
+
+            old_cell = notebook.cells[cell_index]
+            old_type = old_cell.cell_type
+            needs_type_change = cell_type is not None and cell_type != old_type
+            source = content if content is not None else old_cell.source
+
+            changed = False
+            if needs_type_change:
+                cell_id_val = getattr(old_cell, "id", None)
+                metadata = old_cell.get("metadata", {})
+                if cell_type == "code":
+                    new_cell = nbformat.v4.new_code_cell(source=source)
+                elif cell_type == "markdown":
+                    new_cell = nbformat.v4.new_markdown_cell(source=source)
+                else:
+                    new_cell = nbformat.v4.new_raw_cell(source=source)
+                if cell_id_val:
+                    new_cell.id = cell_id_val
+                new_cell.metadata.update(metadata)
+                notebook.cells[cell_index] = new_cell
+                changed = True
+            elif content is not None:
+                old_cell.source = content
+                changed = True
+
+            if changed:
                 with open(file_path, "w", encoding="utf-8") as f:
                     nbformat.write(notebook, f)
-            else:
-                raise ValueError(f"Cell with {cell_id=} not found in notebook at {file_path=}")
 
         return {"success": True}
     except Exception:

--- a/tests/test_edit_cell_type.py
+++ b/tests/test_edit_cell_type.py
@@ -1,0 +1,463 @@
+"""Tests for edit_cell() cell_type parameter."""
+
+import os
+import tempfile
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import nbformat
+import pytest
+
+from jupyter_ai_tools.toolkits.notebook import edit_cell
+
+
+# ── Helpers ──
+
+
+def _make_notebook(*cells):
+    """Create a notebook file with the given cells and return its path."""
+    nb = nbformat.v4.new_notebook()
+    nb.cells = list(cells)
+    fd, path = tempfile.mkstemp(suffix=".ipynb")
+    with os.fdopen(fd, "w") as f:
+        nbformat.write(nb, f)
+    return path
+
+
+def _read_notebook(path):
+    with open(path, "r") as f:
+        return nbformat.read(f, as_version=nbformat.NO_CONVERT)
+
+
+@contextmanager
+def _nbformat_path():
+    """Patch get_file_id and get_jupyter_ydoc so edit_cell takes the nbformat path."""
+    with patch("jupyter_ai_tools.toolkits.notebook.get_file_id", new_callable=AsyncMock), \
+         patch("jupyter_ai_tools.toolkits.notebook.get_jupyter_ydoc", new_callable=AsyncMock, return_value=None):
+        yield
+
+
+@contextmanager
+def _ydoc_path(ydoc, resolved_cell_id="cell-1", cell_index=0):
+    """Patch dependencies so edit_cell takes the YDoc path with the given mock."""
+    with patch("jupyter_ai_tools.toolkits.notebook.get_file_id", new_callable=AsyncMock), \
+         patch("jupyter_ai_tools.toolkits.notebook.get_jupyter_ydoc", new_callable=AsyncMock, return_value=ydoc), \
+         patch("jupyter_ai_tools.toolkits.notebook._get_cell_index_from_id_ydoc", return_value=cell_index), \
+         patch("jupyter_ai_tools.toolkits.notebook.normalize_filepath", side_effect=lambda x: x), \
+         patch("jupyter_ai_tools.toolkits.notebook._resolve_cell_id", new_callable=AsyncMock, return_value=resolved_cell_id):
+        yield
+
+
+def _make_mock_ydoc(cell_type="code", source="print('hello')", cell_id="cell-1", metadata=None):
+    """Build a mock YDoc with a single cell."""
+    ydoc = MagicMock()
+    ycell = MagicMock()
+    cell_py = {
+        "cell_type": cell_type,
+        "source": source,
+        "id": cell_id,
+        "metadata": metadata or {},
+    }
+    if cell_type == "code":
+        cell_py["outputs"] = []
+        cell_py["execution_count"] = None
+    ycell.to_py.return_value = cell_py
+    ydoc._ycells = [ycell]
+    ydoc.set_cell = MagicMock()
+    return ydoc, ycell
+
+
+# ── Fixtures ──
+
+
+@pytest.fixture
+def code_cell():
+    cell = nbformat.v4.new_code_cell(source="print('hello')")
+    cell.id = "cell-1"
+    return cell
+
+
+@pytest.fixture
+def markdown_cell():
+    cell = nbformat.v4.new_markdown_cell(source="# Title")
+    cell.id = "cell-2"
+    return cell
+
+
+@pytest.fixture
+def raw_cell():
+    cell = nbformat.v4.new_raw_cell(source="raw text")
+    cell.id = "cell-3"
+    return cell
+
+
+# ── nbformat path tests ──
+
+
+class TestEditCellTypeNbformat:
+    """Tests for cell type changes via the nbformat (filesystem) path."""
+
+    @pytest.mark.asyncio
+    async def test_code_to_markdown(self, code_cell):
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1", cell_type="markdown")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "markdown"
+            assert cell.source == "print('hello')"
+            assert cell.id == "cell-1"
+            assert "outputs" not in cell
+            assert "execution_count" not in cell
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_code_to_raw(self, code_cell):
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1", cell_type="raw")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "raw"
+            assert cell.source == "print('hello')"
+            assert cell.id == "cell-1"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_markdown_to_code(self, markdown_cell):
+        path = _make_notebook(markdown_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-2", cell_type="code")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "code"
+            assert cell.source == "# Title"
+            assert cell.id == "cell-2"
+            assert cell.outputs == []
+            assert cell.execution_count is None
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_markdown_to_raw(self, markdown_cell):
+        path = _make_notebook(markdown_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-2", cell_type="raw")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "raw"
+            assert cell.source == "# Title"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_raw_to_code(self, raw_cell):
+        path = _make_notebook(raw_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-3", cell_type="code")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "code"
+            assert cell.source == "raw text"
+            assert cell.outputs == []
+            assert cell.execution_count is None
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_raw_to_markdown(self, raw_cell):
+        path = _make_notebook(raw_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-3", cell_type="markdown")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "markdown"
+            assert cell.source == "raw text"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_type_change_with_content(self, code_cell):
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1", content="# New heading", cell_type="markdown")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "markdown"
+            assert cell.source == "# New heading"
+            assert cell.id == "cell-1"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_same_type_edits_content_only(self, code_cell):
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1", content="new code", cell_type="code")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "code"
+            assert cell.source == "new code"
+            assert cell.outputs == []
+            assert cell.execution_count is None
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_content_only_backward_compat(self, code_cell):
+        """cell_type=None only changes content."""
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1", content="updated")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "code"
+            assert cell.source == "updated"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_type_only_preserves_source(self, code_cell):
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1", cell_type="markdown")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.source == "print('hello')"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_preserves_metadata(self, code_cell):
+        code_cell.metadata["custom_key"] = "custom_value"
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1", cell_type="markdown")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.metadata.get("custom_key") == "custom_value"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_code_with_outputs_to_markdown_drops_outputs(self):
+        """Outputs and execution_count should be dropped when converting code→markdown."""
+        cell = nbformat.v4.new_code_cell(source="1+1")
+        cell.id = "cell-out"
+        cell.execution_count = 5
+        cell.outputs = [nbformat.v4.new_output("execute_result", data={"text/plain": "2"})]
+        path = _make_notebook(cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-out", cell_type="markdown")
+
+            result = _read_notebook(path).cells[0]
+            assert result.cell_type == "markdown"
+            assert result.source == "1+1"
+            assert "outputs" not in result
+            assert "execution_count" not in result
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_cell_index_as_string(self, code_cell):
+        """cell_id can be a numeric index string like '0'."""
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "0", cell_type="markdown")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "markdown"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_cell_not_found(self, code_cell):
+        path = _make_notebook(code_cell)
+        try:
+            with _nbformat_path():
+                with pytest.raises(ValueError, match="not found"):
+                    await edit_cell(path, "nonexistent-id", content="x")
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_no_content_no_type_skips_write(self, code_cell):
+        """Both content=None and cell_type=None should not write the file."""
+        path = _make_notebook(code_cell)
+        mtime_before = os.path.getmtime(path)
+        try:
+            with _nbformat_path():
+                await edit_cell(path, "cell-1")
+
+            cell = _read_notebook(path).cells[0]
+            assert cell.cell_type == "code"
+            assert cell.source == "print('hello')"
+            # File should not have been rewritten
+            assert os.path.getmtime(path) == mtime_before
+        finally:
+            os.unlink(path)
+
+
+# ── YDoc path tests ──
+
+
+class TestEditCellTypeYdoc:
+    """Tests for cell type changes via the YDoc (collaborative) path."""
+
+    @pytest.mark.asyncio
+    async def test_code_to_markdown_calls_set_cell(self):
+        ydoc, _ = _make_mock_ydoc(cell_type="code")
+
+        with _ydoc_path(ydoc):
+            await edit_cell("test.ipynb", "cell-1", cell_type="markdown")
+
+        ydoc.set_cell.assert_called_once()
+        new_cell = ydoc.set_cell.call_args[0][1]
+        assert new_cell["cell_type"] == "markdown"
+        assert new_cell["source"] == "print('hello')"
+        assert new_cell["id"] == "cell-1"
+        assert "outputs" not in new_cell
+        assert "execution_count" not in new_cell
+
+    @pytest.mark.asyncio
+    async def test_markdown_to_code_adds_fields(self):
+        ydoc, _ = _make_mock_ydoc(cell_type="markdown", source="# Title", cell_id="cell-2")
+
+        with _ydoc_path(ydoc, resolved_cell_id="cell-2"):
+            await edit_cell("test.ipynb", "cell-2", cell_type="code")
+
+        new_cell = ydoc.set_cell.call_args[0][1]
+        assert new_cell["cell_type"] == "code"
+        assert new_cell["source"] == "# Title"
+        assert new_cell["outputs"] == []
+        assert new_cell["execution_count"] is None
+
+    @pytest.mark.asyncio
+    async def test_raw_to_markdown(self):
+        ydoc, _ = _make_mock_ydoc(cell_type="raw", source="raw text", cell_id="cell-3")
+
+        with _ydoc_path(ydoc, resolved_cell_id="cell-3"):
+            await edit_cell("test.ipynb", "cell-3", cell_type="markdown")
+
+        new_cell = ydoc.set_cell.call_args[0][1]
+        assert new_cell["cell_type"] == "markdown"
+        assert new_cell["source"] == "raw text"
+
+    @pytest.mark.asyncio
+    async def test_raw_to_code(self):
+        ydoc, _ = _make_mock_ydoc(cell_type="raw", source="raw text", cell_id="cell-3")
+
+        with _ydoc_path(ydoc, resolved_cell_id="cell-3"):
+            await edit_cell("test.ipynb", "cell-3", cell_type="code")
+
+        new_cell = ydoc.set_cell.call_args[0][1]
+        assert new_cell["cell_type"] == "code"
+        assert new_cell["outputs"] == []
+        assert new_cell["execution_count"] is None
+
+    @pytest.mark.asyncio
+    async def test_markdown_to_raw(self):
+        ydoc, _ = _make_mock_ydoc(cell_type="markdown", source="# Title", cell_id="cell-2")
+
+        with _ydoc_path(ydoc, resolved_cell_id="cell-2"):
+            await edit_cell("test.ipynb", "cell-2", cell_type="raw")
+
+        new_cell = ydoc.set_cell.call_args[0][1]
+        assert new_cell["cell_type"] == "raw"
+        assert "outputs" not in new_cell
+
+    @pytest.mark.asyncio
+    async def test_type_change_with_content(self):
+        ydoc, _ = _make_mock_ydoc(cell_type="code")
+
+        with _ydoc_path(ydoc):
+            await edit_cell("test.ipynb", "cell-1", content="# New heading", cell_type="markdown")
+
+        new_cell = ydoc.set_cell.call_args[0][1]
+        assert new_cell["source"] == "# New heading"
+        assert new_cell["cell_type"] == "markdown"
+
+    @pytest.mark.asyncio
+    async def test_content_only_uses_atomic_replace(self):
+        ydoc, ycell = _make_mock_ydoc()
+
+        with _ydoc_path(ydoc), \
+             patch("jupyter_ai_tools.toolkits.notebook._atomic_replace_cell_source") as mock_replace:
+            await edit_cell("test.ipynb", "cell-1", content="new code")
+
+        mock_replace.assert_called_once_with(ycell, "new code")
+        ydoc.set_cell.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_same_type_skips_set_cell(self):
+        ydoc, ycell = _make_mock_ydoc(cell_type="code")
+
+        with _ydoc_path(ydoc), \
+             patch("jupyter_ai_tools.toolkits.notebook._atomic_replace_cell_source") as mock_replace:
+            await edit_cell("test.ipynb", "cell-1", content="updated", cell_type="code")
+
+        mock_replace.assert_called_once_with(ycell, "updated")
+        ydoc.set_cell.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_content_no_type_is_noop(self):
+        """Neither set_cell nor _atomic_replace should be called."""
+        ydoc, _ = _make_mock_ydoc()
+
+        with _ydoc_path(ydoc), \
+             patch("jupyter_ai_tools.toolkits.notebook._atomic_replace_cell_source") as mock_replace:
+            await edit_cell("test.ipynb", "cell-1")
+
+        ydoc.set_cell.assert_not_called()
+        mock_replace.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preserves_metadata(self):
+        ydoc, _ = _make_mock_ydoc(metadata={"custom": "value"})
+
+        with _ydoc_path(ydoc):
+            await edit_cell("test.ipynb", "cell-1", cell_type="markdown")
+
+        new_cell = ydoc.set_cell.call_args[0][1]
+        assert new_cell["metadata"] == {"custom": "value"}
+
+    @pytest.mark.asyncio
+    async def test_type_change_with_animate(self):
+        """animate=True + type change should call write_to_cell_collaboratively on the new ycell."""
+        ydoc, _ = _make_mock_ydoc(cell_type="code")
+        new_ycell = MagicMock()
+        ydoc._ycells = [new_ycell]  # After set_cell, the ycell at index 0 is the new one
+
+        with _ydoc_path(ydoc), \
+             patch("jupyter_ai_tools.toolkits.notebook._atomic_replace_cell_source") as mock_replace, \
+             patch("jupyter_ai_tools.toolkits.notebook.write_to_cell_collaboratively", new_callable=AsyncMock) as mock_write:
+            await edit_cell("test.ipynb", "cell-1", content="# Animated", cell_type="markdown", animate=True)
+
+        ydoc.set_cell.assert_called_once()
+        # Should clear the new cell then write collaboratively
+        mock_replace.assert_called_once_with(new_ycell, "")
+        mock_write.assert_called_once_with(ydoc, new_ycell, "# Animated")
+
+    @pytest.mark.asyncio
+    async def test_cell_not_found_raises(self):
+        ydoc, _ = _make_mock_ydoc()
+
+        with _ydoc_path(ydoc, resolved_cell_id="bad-id"), \
+             patch("jupyter_ai_tools.toolkits.notebook._get_cell_index_from_id_ydoc", return_value=None):
+            with pytest.raises(ValueError, match="not found"):
+                await edit_cell("test.ipynb", "bad-id", content="x")


### PR DESCRIPTION
### Add `cell_type` parameter to `edit_cell()`                                                                                                                                                                     
                                                                                                                                                                                                                 
Adds support for changing a notebook cell's type (code/markdown/raw) through the existing edit_cell() function.                                                                                                
                                                                                                                                                                                                                 
#### Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  - edit_cell() now accepts an optional cell_type parameter. When provided and different from the current type, the cell is replaced with correct type-specific fields (e.g., outputs/execution_count added for  
  code, removed for markdown/raw). Cell ID, source, and metadata are preserved.                                                                                                                                  
  - content is now optional — callers can change only the type without re-specifying content.                                                                                                                    
  - YDoc path uses set_cell() for type changes to ensure the frontend properly handles the cell replacement.                                                                                                     
  - nbformat path rebuilds the cell via nbformat.v4.new_*_cell().                                                                                                                                                
  - Fully backward compatible — existing callers are unaffected.                                                                                                                                                 
                                                                                                                                                                                                                 
#### Testing                                                                                                                                                                                                        
- unit tests
- manual edit tests -> changing to markdown and vice versa