### PR TITLE
Fixes edit_cell, delete_cell, move_cell, and relative insert_cell for any environment that does not have jupyter-server-documents installed.

### DIFF
--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -1436,11 +1436,8 @@ def _get_cell_index_from_id_ydoc(ydoc, cell_id: str) -> Optional[int]:
         The index of the cell in the notebook, or None if not found.
     """
     for i, ycell in enumerate(ydoc.ycells):
-        try:
-            if ycell["id"] == cell_id:
-                return i
-        except KeyError:
-            continue
+        if ycell.get("id") == cell_id:
+            return i
     return None
 
 

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -1416,11 +1416,13 @@ def _get_cell_index_from_id_ydoc(ydoc, cell_id: str) -> Optional[int]:
     Returns:
         The index of the cell in the notebook, or None if not found.
     """
-    try:
-        cell_index, _ = ydoc.find_cell(cell_id)
-        return cell_index
-    except (AttributeError, KeyError):
-        return None
+    for i, ycell in enumerate(ydoc.ycells):
+        try:
+            if ycell["id"] == cell_id:
+                return i
+        except KeyError:
+            continue
+    return None
 
 
 def _get_cell_index_from_id_nbformat(notebook, cell_id: str) -> Optional[int]:

--- a/tests/test_get_cell_index_from_id_ydoc.py
+++ b/tests/test_get_cell_index_from_id_ydoc.py
@@ -1,0 +1,61 @@
+"""Tests for _get_cell_index_from_id_ydoc against a real jupyter_ydoc.YNotebook.
+
+These tests exercise the helper directly (no mocks) to verify it works against
+the upstream YNotebook from jupyter_ydoc, which does not define a `find_cell`
+method. The previous implementation called `ydoc.find_cell(...)` and silently
+returned None on AttributeError, making every edit_cell/delete_cell/move_cell
+call fail with a misleading "cell not found" error on installs without
+jupyter-server-documents.
+
+Closes #29.
+"""
+
+from jupyter_ydoc import YNotebook
+
+from jupyter_ai_tools.toolkits.notebook import _get_cell_index_from_id_ydoc
+
+
+def _populate(ydoc, cells):
+    ydoc.set(
+        {
+            "cells": cells,
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    )
+
+
+def test_returns_index_when_cell_id_matches():
+    ydoc = YNotebook()
+    _populate(
+        ydoc,
+        [
+            {"cell_type": "code", "source": "x = 1", "id": "first", "metadata": {}, "outputs": [], "execution_count": None},
+            {"cell_type": "markdown", "source": "# title", "id": "second", "metadata": {}},
+            {"cell_type": "code", "source": "x = 2", "id": "third", "metadata": {}, "outputs": [], "execution_count": None},
+        ],
+    )
+
+    assert _get_cell_index_from_id_ydoc(ydoc, "first") == 0
+    assert _get_cell_index_from_id_ydoc(ydoc, "second") == 1
+    assert _get_cell_index_from_id_ydoc(ydoc, "third") == 2
+
+
+def test_returns_none_when_cell_id_missing():
+    ydoc = YNotebook()
+    _populate(
+        ydoc,
+        [
+            {"cell_type": "code", "source": "x = 1", "id": "only", "metadata": {}, "outputs": [], "execution_count": None},
+        ],
+    )
+
+    assert _get_cell_index_from_id_ydoc(ydoc, "nonexistent") is None
+
+
+def test_returns_none_for_empty_notebook():
+    ydoc = YNotebook()
+    _populate(ydoc, [])
+
+    assert _get_cell_index_from_id_ydoc(ydoc, "anything") is None

--- a/tests/test_get_cell_index_from_id_ydoc.py
+++ b/tests/test_get_cell_index_from_id_ydoc.py
@@ -1,14 +1,4 @@
-"""Tests for _get_cell_index_from_id_ydoc against a real jupyter_ydoc.YNotebook.
-
-These tests exercise the helper directly (no mocks) to verify it works against
-the upstream YNotebook from jupyter_ydoc, which does not define a `find_cell`
-method. The previous implementation called `ydoc.find_cell(...)` and silently
-returned None on AttributeError, making every edit_cell/delete_cell/move_cell
-call fail with a misleading "cell not found" error on installs without
-jupyter-server-documents.
-
-Closes #29.
-"""
+"""Tests for _get_cell_index_from_id_ydoc against a real jupyter_ydoc.YNotebook."""
 
 from jupyter_ydoc import YNotebook
 

--- a/tests/test_get_cell_index_from_id_ydoc.py
+++ b/tests/test_get_cell_index_from_id_ydoc.py
@@ -31,9 +31,23 @@ def test_returns_index_when_cell_id_matches():
     _populate(
         ydoc,
         [
-            {"cell_type": "code", "source": "x = 1", "id": "first", "metadata": {}, "outputs": [], "execution_count": None},
+            {
+                "cell_type": "code",
+                "source": "x = 1",
+                "id": "first",
+                "metadata": {},
+                "outputs": [],
+                "execution_count": None,
+            },
             {"cell_type": "markdown", "source": "# title", "id": "second", "metadata": {}},
-            {"cell_type": "code", "source": "x = 2", "id": "third", "metadata": {}, "outputs": [], "execution_count": None},
+            {
+                "cell_type": "code",
+                "source": "x = 2",
+                "id": "third",
+                "metadata": {},
+                "outputs": [],
+                "execution_count": None,
+            },
         ],
     )
 
@@ -47,7 +61,14 @@ def test_returns_none_when_cell_id_missing():
     _populate(
         ydoc,
         [
-            {"cell_type": "code", "source": "x = 1", "id": "only", "metadata": {}, "outputs": [], "execution_count": None},
+            {
+                "cell_type": "code",
+                "source": "x = 1",
+                "id": "only",
+                "metadata": {},
+                "outputs": [],
+                "execution_count": None,
+            },
         ],
     )
 


### PR DESCRIPTION
 ## Summary

Fixes `edit_cell`, `delete_cell`, `move_cell`, and relative `insert_cell` for any environment that does not have `jupyter-server-documents` installed.

`_get_cell_index_from_id_ydoc` called `ydoc.find_cell(cell_id)`, but `find_cell` is only defined on JSD's `YNotebook(UpstreamYNotebook)` subclass (`jupyter_server_documents/ydocs.py`). It does not exist in upstream `jupyter_ydoc`.

## Fix
Iterate `ydoc.ycells` directly and match on `ycell["id"]` — same approach as JSD's own `find_cell`, but using the public property. Works on both vanilla `jupyter_ydoc.YNotebook` and JSD's subclass (subclass inherits `ycells`). Also drops the `AttributeError` catch that was hiding the underlying API mismatch (per the issue author's suggestion).

Closes #29.

  ## Test plan

- [x] Added `tests/test_get_cell_index_from_id_ydoc.py` exercising the helper directly against a real `jupyter_ydoc.YNotebook` (3 cases: hit, miss, empty notebook).
 - [x] Manually verified end-to-end via the Claude Code ACP plugin on both stacks:
     - Canonical `jupyter-collaboration` + `jupyter_ydoc 3.4.1` (no JSD): edit/delete/move now succeed in the live UI — previously failed with "Cell not found".
     - With `jupyter-server-documents` installed: edit/delete/move continue to work — no regression.