### PR TITLE
Add file_path param to run_cell and run_all_cells

### DIFF
--- a/jupyter_ai_tools/toolkits/jupyterlab.py
+++ b/jupyter_ai_tools/toolkits/jupyterlab.py
@@ -95,7 +95,8 @@ async def run_cell(
                    opened/focused before running and used to resolve the cell.
                    If None, the user's active notebook is used.
         username: Optional username to get the active cell for that specific user.
-                  Ignored when file_path is provided.
+                  Also used when file_path is provided, to pick whose active
+                  cell the cursor navigation starts from.
         timeout: Max seconds to wait (default and max: 10s). A timeout does
                  NOT mean execution failed; the kernel continues running.
 

--- a/jupyter_ai_tools/toolkits/jupyterlab.py
+++ b/jupyter_ai_tools/toolkits/jupyterlab.py
@@ -45,32 +45,44 @@ async def open_file(file_path: str):
     return await execute_command("docmanager:open", {"path": file_path})
 
 
-async def run_all_cells(timeout: Optional[float] = None) -> dict:
-    """Runs all cells in the currently active Jupyter notebook.
+async def run_all_cells(file_path: Optional[str] = None, timeout: Optional[float] = None) -> dict:
+    """Runs all cells in a Jupyter notebook.
 
     Does NOT return cell outputs — call `read_notebook_cells` to inspect results.
 
     Args:
+        file_path: Path to the notebook file. If provided, the notebook is
+                   opened/focused before running. If None, runs in the
+                   currently active notebook.
         timeout: Max seconds to wait (default and max: 10s). A timeout does
                  NOT mean execution failed; the kernel continues running.
 
     Returns:
         dict with `success` (bool) and optional `error` or `result` fields.
     """
+    if file_path:
+        await open_file(file_path)
+
     return await _run_with_timeout(
         execute_command("notebook:run-all-cells"), timeout, "Run all cells started"
     )
 
 
 async def run_cell(
-    cell_id: str, username: Optional[str] = None, timeout: Optional[float] = None
+    cell_id: str,
+    file_path: Optional[str] = None,
+    username: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> dict:
-    """Runs a specific cell in the active notebook by selecting it and executing it.
+    """Runs a specific cell in a notebook by selecting it and executing it.
 
     Does NOT return cell outputs — call `read_notebook_cells` to inspect results.
 
     Args:
         cell_id: The UUID of the cell to run, or a numeric index as string
+        file_path: Path to the notebook file. If provided, the notebook is
+                   opened/focused before running. If None, runs in the
+                   currently active notebook.
         username: Optional username to get the active cell for that specific user
         timeout: Max seconds to wait (default and max: 10s). A timeout does
                  NOT mean execution failed; the kernel continues running.
@@ -79,6 +91,9 @@ async def run_cell(
         dict with `success` (bool) and optional `error` or `result` fields.
     """
     from .notebook import select_cell
+
+    if file_path:
+        await open_file(file_path)
 
     await select_cell(cell_id, username)
 

--- a/jupyter_ai_tools/toolkits/jupyterlab.py
+++ b/jupyter_ai_tools/toolkits/jupyterlab.py
@@ -50,6 +50,10 @@ async def run_all_cells(file_path: Optional[str] = None, timeout: Optional[float
 
     Does NOT return cell outputs — call `read_notebook_cells` to inspect results.
 
+    Valid argument combinations:
+        - `file_path`: Run all cells in the specified notebook.
+        - No arguments: Run all cells in the currently active notebook.
+
     Args:
         file_path: Path to the notebook file. If provided, the notebook is
                    opened/focused before running. If None, runs in the
@@ -61,7 +65,9 @@ async def run_all_cells(file_path: Optional[str] = None, timeout: Optional[float
         dict with `success` (bool) and optional `error` or `result` fields.
     """
     if file_path:
-        await open_file(file_path)
+        result = await open_file(file_path)
+        if not result.get("success"):
+            return result
 
     return await _run_with_timeout(
         execute_command("notebook:run-all-cells"), timeout, "Run all cells started"
@@ -78,12 +84,18 @@ async def run_cell(
 
     Does NOT return cell outputs — call `read_notebook_cells` to inspect results.
 
+    Valid argument combinations:
+        - `file_path` + `cell_id`: Run a specific cell in the given notebook.
+        - `username` + `cell_id`: Run a specific cell in the user's active notebook.
+        - `cell_id` only: Run a specific cell in the currently active notebook.
+
     Args:
-        cell_id: The UUID of the cell to run, or a numeric index as string
+        cell_id: The UUID of the cell to run, or a numeric index as string.
         file_path: Path to the notebook file. If provided, the notebook is
-                   opened/focused before running. If None, runs in the
-                   currently active notebook.
-        username: Optional username to get the active cell for that specific user
+                   opened/focused before running and used to resolve the cell.
+                   If None, the user's active notebook is used.
+        username: Optional username to get the active cell for that specific user.
+                  Ignored when file_path is provided.
         timeout: Max seconds to wait (default and max: 10s). A timeout does
                  NOT mean execution failed; the kernel continues running.
 
@@ -93,9 +105,11 @@ async def run_cell(
     from .notebook import select_cell
 
     if file_path:
-        await open_file(file_path)
+        result = await open_file(file_path)
+        if not result.get("success"):
+            return result
 
-    await select_cell(cell_id, username)
+    await select_cell(cell_id, username, file_path=file_path)
 
     return await _run_with_timeout(
         execute_command("notebook:run-cell"), timeout, "Cell execution started"

--- a/jupyter_ai_tools/toolkits/notebook.py
+++ b/jupyter_ai_tools/toolkits/notebook.py
@@ -1194,12 +1194,16 @@ async def get_open_documents(username: Optional[str] = None) -> Optional[List[st
     return None
 
 
-async def select_cell(cell_id: str, username: Optional[str] = None) -> dict:
+async def select_cell(
+    cell_id: str, username: Optional[str] = None, file_path: Optional[str] = None
+) -> dict:
     """Selects a cell in the active notebook by navigating to it using cursor movements.
 
     Args:
         cell_id: The UUID of the cell to select, or a numeric index as string
         username: Optional username to get the active cell for that specific user
+        file_path: Optional path to the notebook file. If provided, uses this path
+                   instead of deriving the notebook from awareness state.
 
     Returns:
         dict: A dictionary containing the response from the last cursor movement
@@ -1211,7 +1215,8 @@ async def select_cell(cell_id: str, username: Optional[str] = None) -> dict:
     from jupyterlab_commands_toolkit.tools import execute_command
 
     try:
-        file_path = await get_active_notebook(username)
+        if not file_path:
+            file_path = await get_active_notebook(username)
         if not file_path:
             raise RuntimeError("No active notebook found. Please open a notebook first.")
 


### PR DESCRIPTION
**Problem**: run_cell and run_all_cells had no file_path parameter. When multiple notebooks are open, this could confuse the user.
<img width="574" height="251" alt="image (3)" src="https://github.com/user-attachments/assets/d2726b26-5018-46d3-ba2c-2ed684263b37" />


**Fix**: Added file_path to both functions. When provided, it calls open_file(file_path) first to focus the correct notebook, then runs the cell/cells in it.

Fix working as expected in local testing 
<img width="560" height="118" alt="Screenshot 2026-07-08 at 11 23 32 AM" src="https://github.com/user-attachments/assets/46c23cf4-61dc-4ab6-9cc0-ce1c0c70a1af" />

