### PR TITLE
Drop jupyter_ydoc upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
   "jupyter_server>=1.6,<3",
   "pycrdt",
-  "jupyter_ydoc>=3.0.0,<4.0.0",
+  "jupyter_ydoc",
 ]
 
 


### PR DESCRIPTION
## Motivation

The `jupyter_ydoc>=3.0.0,<4.0.0` pin blocks installing jupyter-ai-tools alongside the JupyterLab 4.6 / Jupyter AI 3.1 stack, which pulls a newer `jupyter_ydoc` transitively. The `<4.0.0` cap forces a resolver conflict that keeps the whole stack on the older line.

## Summary

Drops the version specifier on `jupyter_ydoc` entirely. jupyter-ai-tools has no reason to constrain ydoc itself, so it now defers that constraint to the packages that actually depend on a specific version (e.g. `jupyter_server_documents`). This unblocks JupyterLab 4.6.

## Testing

Re-resolved the environment and ran the existing suite (all passing) — this is a dependency-metadata change only.